### PR TITLE
remove unused endpoint and functions

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -43,8 +43,6 @@ library:
   - transformers-base
   - tz
   - tztime
-  - uri-bytestring
-  - uri-bytestring-aeson
 
 executables:
   tzbot-exe:

--- a/src/TzBot/Slack/API.hs
+++ b/src/TzBot/Slack/API.hs
@@ -27,8 +27,6 @@ import Servant
   type (:>))
 import Servant.Auth (Auth, JWT)
 import TzBot.Instances ()
-import URI.ByteString (URI)
-import URI.ByteString.Aeson ()
 
 ----------------------------------------------------------------------------
 -- API
@@ -38,11 +36,6 @@ type RequiredParam = QueryParam' [Required, Strict]
 
 -- | A type describing Slack's Web API: https://api.slack.com/web
 type API =
-  -- See: https://api.slack.com/methods/apps.connections.open
-  Auth '[JWT] Text
-    :> "apps.connections.open"
-    :> Post '[JSON] (SlackResponse "url" URI)
-  :<|>
   -- See: https://api.slack.com/methods/users.info
   Auth '[JWT] Text
     :> "users.info"

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -117,8 +117,6 @@ library
     , tz
     , tztime
     , universum
-    , uri-bytestring
-    , uri-bytestring-aeson
   default-language: Haskell2010
 
 executable tzbot-exe


### PR DESCRIPTION
Problem: `openConnection` endpoint isn't used because web-socket mode starts with the function `runSocketMode` from slacker-package. Therefore unused endpoint and corresponding functions can be safely removed.

Solution: remove unused endpoint and functions
