### PR TITLE
[#7] Cache slack data

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -20,6 +20,8 @@ oauth_config:
 settings:
   event_subscriptions:
     bot_events:
+      - member_joined_channel
+      - member_left_channel
       - message.channels
       - message.groups
   interactivity:

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,8 @@ library:
   - aeson
   - aeson-casing
   - base >= 4.7 && < 5
+  - cache
+  - clock
   - containers
   - fmt
   - dlist
@@ -31,11 +33,13 @@ library:
   - http-client-tls
   - http-types
   - lifted-async
+  - managed
   - megaparsec
   - monad-control
   - mtl
   - nyan-interpolation
   - o-clock
+  - random
   - servant-auth
   - servant-auth-client
   - servant-client
@@ -50,9 +54,10 @@ library:
   - transformers-base
   - tz
   - tztime
+  - unordered-containers
+  - utf8-string
   - validation
   - yaml
-  - utf8-string
 
 executables:
   tzbot-exe:

--- a/src/TzBot/Cache.hs
+++ b/src/TzBot/Cache.hs
@@ -1,0 +1,139 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module TzBot.Cache
+  ( -- * Types
+    RandomizedCache
+
+    -- * Cache creation
+  , withRandomizedCache
+  , withRandomizedCacheDefault
+
+    -- * Altering cache
+  , insertRandomized
+  , fetchWithCacheRandomized
+  , update
+  ) where
+
+import Universum
+
+import Control.Concurrent.Async.Lifted (withAsync)
+import Data.Cache (Cache)
+import Data.Cache qualified as Cache
+import Data.Cache.Internal qualified as CacheI
+import Data.HashMap.Strict qualified as HM
+import System.Clock (TimeSpec)
+import Time (Hour, KnownDivRat, Nanosecond, Time(..), hour, threadDelay, toUnit)
+
+import TzBot.Util (randomTimeSpec, timeToTimespec, (+-))
+
+-- | This datatype uses `Cache` datatype inside, but also
+--   provides a possibility to slightly vary expiration
+--   time randomly around the configured mean value.
+--   Use it when you don't want a bunch of cached data
+--   to expire at once.
+--
+--   Automatic periodical cleaning is also included.
+data RandomizedCache k v = RandomizedCache
+  { rcCache  :: Cache k v
+  , rcExpiry :: TimeSpec
+  , rcExpiryRandomAmplitude :: TimeSpec
+  }
+
+-- | Like `withRandomizedCache` but with reasonable defaults.
+-- Expiry random amplitude is 15% of the expiry time,
+-- default cleaning period of 24 hours is used.
+withRandomizedCacheDefault
+  :: ( KnownDivRat u Nanosecond
+     , Eq k, Hashable k
+     )
+  => Time u -- ^ Expiration time
+  -> (RandomizedCache k v -> IO a) -- ^ Action that uses the cache
+  -> IO a
+withRandomizedCacheDefault expiry =
+  withRandomizedCache expiry (get15PerCent expiry) Nothing
+  where
+    get15PerCent :: Time k -> Time k
+    get15PerCent (Time r) = Time $ r * 0.15
+
+-- | Create randomized cache and run the passed action with it.
+-- Raises `error` on incorrect use.
+withRandomizedCache
+  :: ( KnownDivRat u Nanosecond
+     , Eq k, Hashable k
+     , HasCallStack
+     )
+  => Time u -- ^ Expiration time
+  -> Time u -- ^ Expiration time amplitude (should be less than expiration time)
+  -> Maybe (Time Hour) -- ^ How frequently to purge all expired items
+  -> (RandomizedCache k v -> IO a) -- ^ Action that uses the cache
+  -> IO a
+withRandomizedCache
+    (timeToTimespec -> rcExpiry)
+    (timeToTimespec -> rcExpiryRandomAmplitude)
+    cleaningPeriod
+    action
+  = do
+  when (rcExpiry - rcExpiryRandomAmplitude <= 0) $
+    error "Expiry random amplitude should be lower than the expiry"
+  rcCache <- Cache.newCache $ Just rcExpiry
+  withAsync
+    (cleaningThread (toUnit <$> cleaningPeriod) rcCache)
+    (\_ -> action RandomizedCache {..})
+
+defaultCleaningPeriod :: Time Hour
+defaultCleaningPeriod = hour 24
+
+cleaningThread :: (Eq k, Hashable k) => Maybe (Time Hour) -> Cache k v -> IO ()
+cleaningThread mbCleaningPeriod cache = forever $ do
+  Time.threadDelay cleaningPeriod
+  Cache.purgeExpired cache
+  where
+    cleaningPeriod = fromMaybe defaultCleaningPeriod mbCleaningPeriod
+
+-- | Generate a random expiry time and insert a key/value pair into
+-- the cache with that expiry time.
+insertRandomized
+  :: (Eq k, Hashable k, MonadIO m)
+  => k
+  -> v
+  -> RandomizedCache k v
+  -> m ()
+insertRandomized key val RandomizedCache {..} = do
+  let (minTimeSpec, maxTimeSpec) = rcExpiry +- rcExpiryRandomAmplitude
+  rndVal <- liftIO $ randomTimeSpec (minTimeSpec, maxTimeSpec)
+  liftIO $ Cache.insert' rcCache (Just rndVal) key val
+
+-- | Try to get a value by the key from the cache, delete if it is expired.
+-- If the value is either absent or expired, perform given fetch action
+-- and insert the obtained value with configured expiration parameters
+-- into the cache.
+fetchWithCacheRandomized
+  :: (Eq k, Hashable k, MonadIO m)
+  => k
+  -> (k -> m v)
+  -> RandomizedCache k v
+  -> m v
+fetchWithCacheRandomized key fetchAction cache = do
+  mv <- liftIO $ Cache.lookup (rcCache cache) key
+  case mv of
+    Just v -> pure v
+    Nothing -> do
+      v <- fetchAction key
+      insertRandomized key v cache
+      pure v
+
+-- | Update the value by the key, expiration is not taken into account.
+update
+  :: forall k v m. (Eq k, Hashable k, MonadIO m)
+  => k
+  -> (v -> v)
+  -> RandomizedCache k v
+  -> m ()
+update key valFunc RandomizedCache {..} = do
+  atomically $ modifyTVar' (CacheI.container rcCache) $ \hm ->
+    HM.adjust itemFunc key hm
+  where
+    itemFunc :: CacheI.CacheItem v -> CacheI.CacheItem v
+    itemFunc ci = ci { CacheI.item = valFunc $ CacheI.item ci }

--- a/src/TzBot/Config.hs
+++ b/src/TzBot/Config.hs
@@ -2,13 +2,13 @@
 --
 -- SPDX-License-Identifier: MPL-2.0
 
-module TzBot.Config (
-  readConfig,
-  module Types,
+module TzBot.Config
+  ( readConfig
+  , module Types
 
-  -- * These two are needed only for tests
-  readConfigWithEnv,
-  LoadConfigError (..)
+    -- * These two are needed only for tests
+  , readConfigWithEnv
+  , LoadConfigError (..)
   ) where
 
 import Universum hiding (lift)
@@ -16,18 +16,20 @@ import Universum hiding (lift)
 import Control.Exception (evaluate, handle)
 import Data.List (singleton)
 import Data.Map qualified as M
-import Data.String.Conversions
-import Data.Validation
+import Data.String.Conversions (cs)
+import Data.Validation (Validation, bindValidation, fromEither, toEither, validate)
 import Data.Yaml (FromJSON, decodeEither', toJSON)
 import Data.Yaml qualified as Y
 import Data.Yaml.Config (ignoreEnv, loadYamlSettings)
-import Fmt
+import Fmt (Buildable(..), pretty)
 import System.Environment qualified as Env
 import System.IO.Unsafe (unsafePerformIO)
-import Text.Interpolation.Nyan
+import Text.Interpolation.Nyan (int, rmode')
 
-import TzBot.Config.Default
+import TzBot.Config.Default (defaultConfigTrick)
 import TzBot.Config.Types as Types
+  (AppLevelToken(..), BotToken(..), Config(..), ConfigField, ConfigStage(..), Env, EnvVarName,
+  FieldName, appTokenEnv, botTokenEnv, cacheConvMembersEnv, cacheUsersEnv, maxRetriesEnv)
 import TzBot.Instances ()
 
 data LoadConfigError =

--- a/src/TzBot/Config/Default.hs
+++ b/src/TzBot/Config/Default.hs
@@ -9,11 +9,11 @@ module TzBot.Config.Default (
 
 import Universum
 
-import Text.Interpolation.Nyan
+import Text.Interpolation.Nyan (int, rmode')
 
-import TzBot.Config.Types
+import TzBot.Config.Types qualified as CT
 import TzBot.Instances ()
-import TzBot.Util
+import TzBot.Util (Trick, thTrickYaml)
 
 defaultConfigText :: ByteString
 defaultConfigText = [int||
@@ -26,34 +26,34 @@ defaultConfigText = [int||
 
 # Slack application token,
 # see https://api.slack.com/apps/[application_id] for details.
-# Envvar: #{appTokenEnv}
+# Envvar: #{CT.appTokenEnv}
 #
 # appToken: <app-token>
 
 # Bot authentication token,
 # see https://api.slack.com/apps/[application_id]/oauth for details.
-# Envvar: #{botTokenEnv}
+# Envvar: #{CT.botTokenEnv}
 #
 # botToken: <bot-token>
 
 # Maximum allowed times to retry on 429 error before giving up.
-# Envvar: #{maxRetriesEnv}
+# Envvar: #{CT.maxRetriesEnv}
 #
 maxRetries: 3
 
 # Caching expiration time for user profile info.
 # Format examples: 2d18h40m, 3m20s, 20m.
-# Envvar: #{cacheUsersEnv}
+# Envvar: #{CT.cacheUsersEnv}
 #
 cacheUsersInfo: 3m
 
 # Caching expiration time for channel members info.
 # Format examples: 2d18h40m, 3m20s, 20m.
-# Envvar: #{cacheConvMembersEnv}
+# Envvar: #{CT.cacheConvMembersEnv}
 #
 cacheConversationMembers: 3m
   |]
 
 -- This prevents Config.Default.defaultConfigText to be incorrect on compiling.
-defaultConfigTrick :: Trick (Config 'CSInterm)
+defaultConfigTrick :: Trick (CT.Config 'CT.CSInterm)
 defaultConfigTrick = thTrickYaml defaultConfigText

--- a/src/TzBot/Config/Types.hs
+++ b/src/TzBot/Config/Types.hs
@@ -8,12 +8,12 @@ module TzBot.Config.Types where
 
 import Universum
 
-import Data.Aeson
-import Data.Data
-import Time
+import Data.Aeson (FromJSON(parseJSON), ToJSON(toJSON), genericParseJSON, genericToJSON)
+import Data.Data (Data)
+import Time (Minute, Time)
 
 import TzBot.Instances ()
-import TzBot.Util
+import TzBot.Util (aesonConfigOptions)
 
 type FieldName = String
 type EnvVarName = String
@@ -63,11 +63,11 @@ data Config f = Config
 deriving stock instance Eq (Config 'CSInterm)
 deriving stock instance Show (Config 'CSInterm)
 instance FromJSON (Config 'CSInterm) where
-  parseJSON = genericParseJSON aesonConfigOption
+  parseJSON = genericParseJSON aesonConfigOptions
 instance ToJSON (Config 'CSInterm) where
-  toJSON = genericToJSON aesonConfigOption
+  toJSON = genericToJSON aesonConfigOptions
 
 deriving stock instance Eq (Config 'CSFinal)
 deriving stock instance Show (Config 'CSFinal)
 instance FromJSON (Config 'CSFinal) where
-  parseJSON = genericParseJSON aesonConfigOption
+  parseJSON = genericParseJSON aesonConfigOptions

--- a/src/TzBot/Instances.hs
+++ b/src/TzBot/Instances.hs
@@ -5,17 +5,17 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | A module with orphan instances.
-module TzBot.Instances where
+module TzBot.Instances () where
 
 import Universum
 
-import Data.Aeson
+import Data.Aeson (FromJSON(parseJSON), ToJSON(toJSON), Value(String), withText)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Time.Zones.All (TZLabel, toTZName)
 import Data.Time.Zones.All qualified as TZ
-import Formatting.Buildable
-import Time
+import Formatting.Buildable (Buildable(..))
+import Time (KnownRatName, Time, unitsF, unitsP)
 
 instance Buildable TZLabel where
   build = build . T.decodeUtf8 . toTZName

--- a/src/TzBot/Parser.hs
+++ b/src/TzBot/Parser.hs
@@ -2,7 +2,9 @@
 --
 -- SPDX-License-Identifier: MPL-2.0
 
-module TzBot.Parser where
+module TzBot.Parser
+  ( parseTimeRefs
+  ) where
 
 import Universum hiding (toList, try)
 
@@ -15,8 +17,8 @@ import Data.Time.Zones.All (tzNameLabelMap)
 import Text.Megaparsec (Parsec, anySingle, choice, match, parseMaybe, takeRest, try)
 import Text.Megaparsec.Char (char, digitChar, space, space1, string')
 import Text.Megaparsec.Char.Lexer (decimal)
-import TzBot.TimeReference
 
+import TzBot.TimeReference
 
 type TzParser = Parsec Void Text
 

--- a/src/TzBot/RunMonad.hs
+++ b/src/TzBot/RunMonad.hs
@@ -8,22 +8,25 @@ import Universum
 
 import Control.Monad.Base (MonadBase)
 import Control.Monad.Except (MonadError)
-import Control.Monad.Trans.Control
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Map qualified as M
 import Data.Set qualified as S
 import Data.Text.IO qualified as T
 import Network.HTTP.Client (Manager)
 import Servant.Client (ClientError)
-import Text.Interpolation.Nyan
+import Text.Interpolation.Nyan (int, rmode')
 
-import TzBot.Config
-import TzBot.Slack.API
-import TzBot.TimeReference
+import TzBot.Cache (RandomizedCache)
+import TzBot.Config.Types (BotConfig)
+import TzBot.Slack.API (ChannelId, MessageId, User, UserId)
+import TzBot.TimeReference (TimeReferenceText)
 
 data BotState = BotState
   { bsConfig :: BotConfig
   , bsManager :: Manager
   , bsMessagesReferences :: IORef (M.Map MessageId (S.Set TimeReferenceText))
+  , bsUserInfoCache :: RandomizedCache UserId User
+  , bsConversationMembersCache :: RandomizedCache ChannelId (S.Set UserId)
   }
 
 newtype BotM a = BotM

--- a/src/TzBot/Slack/API.hs
+++ b/src/TzBot/Slack/API.hs
@@ -18,16 +18,18 @@ module TzBot.Slack.API
 
 import Universum
 
-import Data.Aeson
+import Data.Aeson (FromJSON(parseJSON), ToJSON, Value, withObject, (.:), (.:?))
 import Data.Aeson.Casing (aesonPrefix, snakeCase)
 import Data.Aeson.Key qualified as Key
-import Data.Aeson.TH
+import Data.Aeson.TH (deriveFromJSON)
 import Data.Time.Zones.All (TZLabel)
+import Formatting (Buildable)
 import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 import Servant
   (Get, JSON, Post, QueryParam, QueryParam', Required, Strict, ToHttpApiData, type (:<|>),
   type (:>))
 import Servant.Auth (Auth, JWT)
+
 import TzBot.Instances ()
 
 ----------------------------------------------------------------------------
@@ -109,12 +111,12 @@ instance (KnownSymbol key, FromJSON a) => FromJSON (SlackContents key a) where
 ----------------------------------------------------------------------------
 
 newtype UserId = UserId { unUserId :: Text }
-  deriving stock (Eq, Show)
-  deriving newtype (ToHttpApiData, FromJSON)
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (ToHttpApiData, FromJSON, ToJSON, Hashable, Buildable)
 
 newtype ChannelId = ChannelId { unChannelId :: Text }
   deriving stock (Eq, Show)
-  deriving newtype (ToHttpApiData, FromJSON)
+  deriving newtype (ToHttpApiData, FromJSON, ToJSON, Hashable, Buildable)
 
 newtype ThreadId = ThreadId { unThreadId :: Text }
   deriving stock (Eq, Show)

--- a/src/TzBot/Slack/EphemeralMessage.hs
+++ b/src/TzBot/Slack/EphemeralMessage.hs
@@ -13,7 +13,7 @@ import Data.Time.Compat
 import Data.Time.TZInfo qualified as TZI
 import Data.Time.TZTime qualified as TZT
 import Data.Time.Zones.All (TZLabel)
-import Text.Interpolation.Nyan
+import Text.Interpolation.Nyan (int, rmode')
 
 import TzBot.Instances ()
 import TzBot.Slack.API (User(uTz))

--- a/src/TzBot/Util.hs
+++ b/src/TzBot/Util.hs
@@ -8,21 +8,48 @@ import Universum
 
 import Data.Aeson (FromJSON(..))
 import Data.Aeson qualified as Aeson
-import Data.Aeson.Casing
+import Data.Aeson.Casing (aesonPrefix, camelCase, snakeCase)
 import Data.Yaml qualified as Y
-import Language.Haskell.TH
+import Language.Haskell.TH (Exp, Q)
+import System.Clock (TimeSpec, fromNanoSecs, toNanoSecs)
+import System.Random (randomRIO)
+import Time (KnownDivRat, Nanosecond, Time, floorRat, ns, toUnit)
 
 attach :: (Functor f) => (a -> b) -> f a -> f (a, b)
 attach f = fmap (\x -> (x, f x))
 
--- | Options that we use to derive JSON instances for config types.
-aesonConfigOption :: Aeson.Options
-aesonConfigOption = (aesonPrefix camelCase){Aeson.rejectUnknownFields = True}
+aesonStripLowercasePrefixOptions :: Aeson.Options
+aesonStripLowercasePrefixOptions = aesonPrefix snakeCase
 
--- | Usage: $(fst trick) $ snd trick, where (trick :: Trick a) is defined in another module.
+-- | Options that we use to derive JSON instances for config types.
+aesonConfigOptions :: Aeson.Options
+aesonConfigOptions = (aesonPrefix camelCase){Aeson.rejectUnknownFields = True}
+
+-- | Usage: $(fst trick) $ snd trick, where (trick :: Trick a)
+--   is defined in another module.
 type Trick a = (Q Exp, a)
 
 thTrickYaml :: forall a. (FromJSON a) => ByteString -> Trick a
 thTrickYaml input = case first show $ Y.decodeEither' input of
   Left str -> (fail str, error "")
   Right c -> ([|id|], c)
+
+timeToTimespec :: KnownDivRat k Nanosecond => Time k -> TimeSpec
+timeToTimespec = fromNanoSecs . floorRat . toUnit @Nanosecond
+
+timespecToTime :: KnownDivRat Nanosecond k => TimeSpec -> Time k
+timespecToTime = toUnit . ns . fromIntegral . toNanoSecs
+
+{-
+>>> import Time
+>>> let Just time = unitsP "30m" :: Maybe (Time Minute)
+>>> (timespecToTime $ timeToTimespec time :: Time Minute) == time
+True
+ -}
+
+randomTimeSpec :: (TimeSpec, TimeSpec) -> IO TimeSpec
+randomTimeSpec (min, max) =
+  fromNanoSecs <$> randomRIO (toNanoSecs min, toNanoSecs max)
+
+(+-) :: Num a => a -> a -> (a, a)
+x +- y = (x - y, x + y)

--- a/test/Test/TzBot/ConfigSpec.hs
+++ b/test/Test/TzBot/ConfigSpec.hs
@@ -12,13 +12,16 @@ import Data.Map qualified as M
 import Test.Hspec (it, shouldBe, shouldSatisfy)
 import Test.Hspec.QuickCheck (prop)
 import Test.Tasty hiding (after_)
-import Test.Tasty.Hspec
+import Test.Tasty.Hspec (testSpec)
 
 import TzBot.Config
-import TzBot.Config.Default
+  (LoadConfigError(..), appTokenEnv, botTokenEnv, cacheConvMembersEnv, cacheUsersEnv, maxRetriesEnv,
+  readConfigWithEnv)
+import TzBot.Config.Default (defaultConfigText)
 
 test_configSpec :: IO TestTree
-test_configSpec = testGroup "Config" <$> sequence [defaultConfigSpec, configLoadingSpec]
+test_configSpec =
+  testGroup "Config" <$> sequence [defaultConfigSpec, configLoadingSpec]
 
 defaultConfigSpec :: IO TestTree
 defaultConfigSpec =
@@ -62,7 +65,8 @@ configLoadingSpec =
       eithConfig `shouldSatisfy` \case
         Left [LCEYamlParseError _] -> True
         _ -> False
-    it "should report all the missing required fields/envvars and the envvars with incorrect contents" $ do
+    it "should report all the missing required fields/envvars\
+                    \ and the envvars with incorrect contents" $ do
       let env = M.fromList $
             [ (botTokenEnv, "bot-token")
             , (maxRetriesEnv, "mazda")
@@ -88,7 +92,8 @@ configLoadingSpec =
         Left
           [LCEInvalidValue "maxRetries" "Must be in range from 0 to 3"] -> maxRetries < 0 || maxRetries > 3
         _ -> maxRetries >= 0 && maxRetries <=3
-    it "should succeed with the valid config file and the environment containing only secrets" $ do
+    it "should succeed with the valid config file and\
+                      \ the environment containing only secrets" $ do
       let env = M.fromList $
             [ (botTokenEnv, "bot-token")
             , (appTokenEnv, "app-token")

--- a/test/Test/TzBot/TimeReferenceToUtcSpec.hs
+++ b/test/Test/TzBot/TimeReferenceToUtcSpec.hs
@@ -16,6 +16,10 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
 import TzBot.TimeReference
+  (DateReference(DayOfMonthRef, DayOfWeekRef, DaysFromToday),
+  LocationReference(OffsetRef, TimeZoneAbbreviationRef, TimeZoneRef), Offset(Offset),
+  TimeReference(TimeReference), TimeReferenceToUTCResult(..),
+  TimeZoneAbbreviation(TimeZoneAbbreviation), timeReferenceToUTC)
 
 time1 :: UTCTime
 time1 = toUTC [tz|2022-12-14 10:30:00 [Europe/Helsinki]|] -- Wednesday
@@ -52,133 +56,171 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
   [ testGroup "Time reference without date and location references"
     [ testCase "Today" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 20 30 0) Nothing Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 20 30 0) Nothing Nothing
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-14 18:30:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-14 18:30:00 [UTC]|]) (Left label1)
           }
     , testCase "Tomorrow" $
         mkTestCase $ TestEntry
           { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) Nothing Nothing
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-15 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-15 06:00:00 [UTC]|]) (Left label1)
           }
     ]
   , testGroup "Time reference without location reference" $
     [ testCase "Days from today" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DaysFromToday 1) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DaysFromToday 1) Nothing
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-15 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-15 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of week, Wednesday -> Monday" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfWeekRef Monday) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfWeekRef Monday) Nothing
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-19 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-19 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of week, Wednesday -> Friday" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfWeekRef Friday) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfWeekRef Friday) Nothing
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-16 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-16 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of week, Wednesday -> Wednesday" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfWeekRef Wednesday) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfWeekRef Wednesday) Nothing
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-14 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-14 06:00:00 [UTC]|]) (Left label1)
           }
 
     , testCase "Day of month, new year" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 2 Nothing) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 2 Nothing) Nothing
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2023-01-02 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2023-01-02 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of month, search for exactly matching candidate (not the closest)" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 31 Nothing) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 31 Nothing) Nothing
           , teUserLabel = label1
           , teCurrentTime = toUTC [tz|2022-11-29 10:00:00 [Europe/Helsinki]|]
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-31 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-31 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of month, prefer past days if they are much closer" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 25 Nothing) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 25 Nothing) Nothing
           , teUserLabel = label1
           , teCurrentTime = toUTC [tz|2022-12-03 10:00:00 [Europe/Helsinki]|]
-          , teResult = TRTUSuccess (toUTC [tz|2022-11-25 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-11-25 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of month, prefer future days if they are slightly further" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 22 Nothing) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 22 Nothing) Nothing
           , teUserLabel = label1
           , teCurrentTime = toUTC [tz|2022-12-03 10:00:00 [Europe/Helsinki]|]
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-22 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-22 06:00:00 [UTC]|]) (Left label1)
           }
 
     , testCase "Day of month and month of year, 1" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 14 (Just 1)) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 14 (Just 1)) Nothing
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2023-01-14 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2023-01-14 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of month and month of year, prefer future day if it's further" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 10 (Just 2)) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 10 (Just 2)) Nothing
           , teUserLabel = label1
           , teCurrentTime = toUTC [tz|2022-06-15 10:00:00 [Europe/Helsinki]|]
-          , teResult = TRTUSuccess (toUTC [tz|2023-02-10 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2023-02-10 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of month and month of year, prefer past day if it's much closer" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 10 (Just 4)) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 10 (Just 4)) Nothing
           , teUserLabel = label1
           , teCurrentTime = toUTC [tz|2022-06-15 10:00:00 [Europe/Helsinki]|]
-          , teResult = TRTUSuccess (toUTC [tz|2022-04-10 05:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-04-10 05:00:00 [UTC]|]) (Left label1)
           }
 
-    , testCase "Time reference without location reference, day of month and month of year, same day" $
+    , testCase "Time reference without location reference,\
+                            \ day of month and month of year, same day" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 14 (Just 12)) Nothing
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0) (Just $ DayOfMonthRef 14 (Just 12)) Nothing
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-14 06:00:00 [UTC]|]) (Left label1)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-14 06:00:00 [UTC]|]) (Left label1)
           }
     ]
   , testCase "Custom time ref" $
       mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DaysFromToday 2) (Just $ TimeZoneRef Asia__Tashkent)
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0)
+                (Just $ DaysFromToday 2) (Just $ TimeZoneRef Asia__Tashkent)
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-16 03:00:00 [UTC]|]) (Left Asia__Tashkent)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-16 03:00:00 [UTC]|]) (Left Asia__Tashkent)
           }
   , testCase "Explicit offset" $ do
       let offset = Offset $ 3 * hour
       mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DaysFromToday 2) (Just $ OffsetRef offset)
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 8 0 0)
+                (Just $ DaysFromToday 2) (Just $ OffsetRef offset)
           , teUserLabel = label1
           , teCurrentTime = time1
-          , teResult = TRTUSuccess (toUTC [tz|2022-12-16 05:00:00 [UTC]|]) (Right offset)
+          , teResult =
+              TRTUSuccess (toUTC [tz|2022-12-16 05:00:00 [UTC]|]) (Right offset)
           }
   , testCase "Valid timezone abbreviation" $
       mkTestCase $ TestEntry
-        { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DaysFromToday 2) (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "MSK")
+        { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DaysFromToday 2)
+                      (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "MSK")
         , teUserLabel = label1
         , teCurrentTime = time1
-        , teResult = TRTUSuccess (toUTC [tz|2022-12-16 05:00:00 [UTC]|]) (Right $ Offset $ 3 * hour)
+        , teResult =
+          TRTUSuccess (toUTC [tz|2022-12-16 05:00:00 [UTC]|]) (Right $ Offset $ 3 * hour)
         }
   , testCase "Invalid timezone abbreviation" $
       mkTestCase $ TestEntry
-        { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DaysFromToday 2) (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "MKS")
+        { teTimeRef =
+            TimeReference "" (TimeOfDay 8 0 0) (Just $ DaysFromToday 2)
+              (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "MKS")
         , teUserLabel = label1
         , teCurrentTime = time1
         , teResult = TRTUInvalidTimeZoneAbbrev "MKS"
@@ -186,7 +228,9 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
   , testGroup "Timeshift subtleties" $
     [ testCase "Turn on DST, explicit time zone, Havana, Cuba" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 0 30 0) (Just $ DaysFromToday 2) (Just $ TimeZoneRef labelHavana)
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 0 30 0)
+                (Just $ DaysFromToday 2) (Just $ TimeZoneRef labelHavana)
           , teUserLabel = labelHavana
           , teCurrentTime = time2
           , teResult = TRTUInvalid
@@ -194,7 +238,9 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
     , testCase "Turn on DST, explicit offset, Havana, Cuba" $ do
         let offset = Offset $ hour * (-5)
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 0 30 0) (Just $ DaysFromToday 2) (Just $ OffsetRef offset)
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 0 30 0)
+                (Just $ DaysFromToday 2) (Just $ OffsetRef offset)
           , teUserLabel = labelHavana
           , teCurrentTime = time2
           , teResult = TRTUSuccess (toUTC [tz|2022-03-13 05:30:00 [UTC]|]) (Right offset)
@@ -202,14 +248,18 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
     , testCase "Turn on DST, explicit offset abbreviation, Havana, Cuba" $ do
         let offset = Offset $ hour * (-5)
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 0 30 0) (Just $ DaysFromToday 2) (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "CDT")
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 0 30 0) (Just $ DaysFromToday 2)
+                (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "CDT")
           , teUserLabel = labelHavana
           , teCurrentTime = time2
           , teResult = TRTUSuccess (toUTC [tz|2022-03-13 05:30:00 [UTC]|]) (Right offset)
           }
     , testCase "Turn off DST, explicit time zone, Havana, Cuba" $
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 0 30 0) (Just $ DaysFromToday 2) (Just $ TimeZoneRef labelHavana)
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 0 30 0)
+                (Just $ DaysFromToday 2) (Just $ TimeZoneRef labelHavana)
           , teUserLabel = labelHavana
           , teCurrentTime = time3
           , teResult = TRTUAmbiguous
@@ -217,7 +267,9 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
     , testCase "Turn off DST, explicit offset, Havana, Cuba" $ do
         let offset = Offset $ hour * (-5)
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 0 30 0) (Just $ DaysFromToday 2) (Just $ OffsetRef offset)
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 0 30 0)
+                (Just $ DaysFromToday 2) (Just $ OffsetRef offset)
           , teUserLabel = labelHavana
           , teCurrentTime = time3
           , teResult = TRTUSuccess (toUTC [tz|2022-11-06 05:30:00 [UTC]|]) (Right offset)
@@ -225,7 +277,9 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
     , testCase "Turn off DST, explicit offset abbreviation, Havana, Cuba" $ do
         let offset = Offset $ hour * (-5)
         mkTestCase $ TestEntry
-          { teTimeRef = TimeReference "" (TimeOfDay 0 30 0) (Just $ DaysFromToday 2) (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "CDT")
+          { teTimeRef =
+              TimeReference "" (TimeOfDay 0 30 0) (Just $ DaysFromToday 2)
+                (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "CDT")
           , teUserLabel = labelHavana
           , teCurrentTime = time3
           , teResult = TRTUSuccess (toUTC [tz|2022-11-06 05:30:00 [UTC]|]) (Right offset)

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -25,6 +25,7 @@ source-repository head
 library
   exposed-modules:
       TzBot.BotMain
+      TzBot.Cache
       TzBot.Config
       TzBot.Config.Default
       TzBot.Config.Types
@@ -98,6 +99,8 @@ library
       aeson
     , aeson-casing
     , base >=4.7 && <5
+    , cache
+    , clock
     , containers
     , dlist
     , fmt
@@ -106,11 +109,13 @@ library
     , http-client-tls
     , http-types
     , lifted-async
+    , managed
     , megaparsec
     , monad-control
     , mtl
     , nyan-interpolation
     , o-clock
+    , random
     , servant-auth
     , servant-auth-client
     , servant-client
@@ -126,6 +131,7 @@ library
     , tz
     , tztime
     , universum
+    , unordered-containers
     , utf8-string
     , validation
     , yaml


### PR DESCRIPTION


## Description

Problem: The bot uses two methods, `getUser` and `getChannelMembers`, which are subjects to Slack's rate limits, and we need to avoid unneeded calls to those methods.

Solution: Add caching for user info and channel members.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #7

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
