### PR TITLE
[#8] Handle Slack pagination

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ library:
   - base >= 4.7 && < 5
   - containers
   - fmt
+  - dlist
   - formatting
   - http-client
   - http-client-tls

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -99,6 +99,7 @@ library
     , aeson-casing
     , base >=4.7 && <5
     , containers
+    , dlist
     , fmt
     , formatting
     , http-client


### PR DESCRIPTION

## Description

Problem: Some Slack methods are paginated and hence can return not all objects if the limit turns out to be less than total amount of the objects.

Solution: Handle pagination by cursor following, fetching all available objects.


## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #8 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
