### PR TITLE
Handle 429 Too Many Requests

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -51,8 +51,6 @@ library:
   - tztime
   - validation
   - yaml
-  - uri-bytestring
-  - uri-bytestring-aeson
   - utf8-string
 
 executables:

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ library:
   - formatting
   - http-client
   - http-client-tls
+  - http-types
   - lifted-async
   - megaparsec
   - monad-control
@@ -37,6 +38,7 @@ library:
   - servant-auth
   - servant-auth-client
   - servant-client
+  - servant-client-core
   - servant-server
   - slacker
   - string-conversions
@@ -49,6 +51,9 @@ library:
   - tztime
   - validation
   - yaml
+  - uri-bytestring
+  - uri-bytestring-aeson
+  - utf8-string
 
 executables:
   tzbot-exe:
@@ -82,6 +87,11 @@ tests:
     - tasty-hunit
     - time
     - tztime
+    - QuickCheck
+    - http-types
+    - servant-client-core
+    - tasty-quickcheck
+    - time
     - universum
 
 ghc-options:

--- a/src/TzBot/BotMain.hs
+++ b/src/TzBot/BotMain.hs
@@ -6,7 +6,7 @@ module TzBot.BotMain where
 
 import Universum
 
-import Data.Aeson.Types
+import Data.Aeson.Types (FromJSON(parseJSON), parseEither)
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Network.HTTP.Client (newManager)
@@ -18,7 +18,7 @@ import System.Environment (getArgs)
 
 import TzBot.Config (AppLevelToken(..), BotToken(..), Config(cAppToken, cBotToken), readConfig)
 import TzBot.ProcessEvent (processEvent)
-import TzBot.RunMonad
+import TzBot.RunMonad (BotState(BotState), log', runBotM)
 
 {- |
 

--- a/src/TzBot/ProcessEvent.hs
+++ b/src/TzBot/ProcessEvent.hs
@@ -88,7 +88,7 @@ processEvent evt = when (newMessageOrEditedMessage evt) $ do
     let notBotAndSameTimeZone u = not (uIsBot u) && uTz u /= uTz sender
         notSender userId = userId /= uId sender
     usersToNotify <- filter notBotAndSameTimeZone <$> (mapM getUser $ filter notSender usersInChannelIds)
---    usersToNotify <- mapM getUser usersInChannelIds -- dev
+    -- usersToNotify <- mapM getUser usersInChannelIds -- dev
 
     forConcurrently_ usersToNotify $ \userToNotify -> do
       let ephemeralMessage = renderEphemeralMessageForOthers userToNotify ephemeralTemplate

--- a/src/TzBot/Slack.hs
+++ b/src/TzBot/Slack.hs
@@ -13,19 +13,26 @@ module TzBot.Slack
   , BotException(..)
   , getUser
   , getChannelMembers
+  , handleTooManyRequests
   , sendEphemeralMessage
   ) where
 
-import Universum
+import Universum hiding (toString)
 
+import Control.Concurrent (threadDelay)
 import Control.Monad.Except (throwError)
 import Data.Aeson (Value)
+import Data.ByteString.UTF8 (toString)
+import Data.Sequence qualified as Seq
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
+import Network.HTTP.Types.Status (Status(statusCode))
 import Servant ((:<|>)(..))
 import Servant.Auth.Client qualified as Auth
 import Servant.Client
   (BaseUrl(BaseUrl), ClientM, Scheme(Https), client, hoistClient, mkClientEnv, runClientM)
+import Servant.Client.Core
+  (ClientError(FailureResponse), ResponseF(responseHeaders, responseStatusCode))
 
 import TzBot.Config
 import TzBot.RunMonad
@@ -84,7 +91,46 @@ usersInfo
     naturalTransformation :: ClientM a -> BotM a
     naturalTransformation act = BotM do
       manager <- asks bsManager
+      config <- asks bsConfig
       let clientEnv = mkClientEnv manager baseUrl
-      liftIO (runClientM act clientEnv) >>= \case
+      liftIO (evalStateT (handleTooManyRequests (runClientM act clientEnv)) (cMaxRetries config)) >>= \case
         Right a -> pure a
         Left clientError -> throwError $ ServantError clientError
+
+-- | Handles slack API response with status code 429 @Too many requests@.
+-- If action result is success, then return result. If action result is error
+-- with response status code 429 and attempts are not exceeded then try the action again.
+handleTooManyRequests :: IO (Either ClientError a) -> StateT Int IO (Either ClientError a)
+handleTooManyRequests botAction = do
+  result <- liftIO botAction
+  case result of
+    Right _ -> return result
+    Left err -> handle err
+  where
+    handle err = case err of
+        FailureResponse _ response ->
+          if ((statusCode . responseStatusCode $ response) == 429)
+          -- TODO: Add logging when handling 429 response status code
+            then do
+              attempts <- get
+              if attempts > 0
+                then do
+                  let retryAfterHeader =
+                        Seq.filter ((== "Retry-After") . fst) (responseHeaders response)
+                  if Seq.null retryAfterHeader
+                    then return $ Left err -- if there is no Retri-After header don't handle 429 response
+                    else do
+                      let retryAfter =
+                            fmap (ceiling . (* 10^(6 :: Int)))
+                                (readMaybe $
+                                  toString . snd $
+                                  Seq.index retryAfterHeader 0 :: Maybe Double)
+                      maybe (pure $ Left err) (waitAndTryAgain botAction) retryAfter
+                else return $ Left err -- if number of attempts are exceeded don't try anymore
+            else return $ Left err -- if response code is other than 429 don't do anything
+        _ -> return $ Left err -- if servant response is other than FailureResponse don't do anything
+    waitAndTryAgain :: IO (Either ClientError a) -> Int -> StateT Int IO (Either ClientError a)
+    waitAndTryAgain action delay = do
+      liftIO . threadDelay $ delay
+      modify (subtract 1)
+      handleTooManyRequests action

--- a/test/Test/TzBot/ConfigSpec.hs
+++ b/test/Test/TzBot/ConfigSpec.hs
@@ -10,6 +10,7 @@ import Universum
 
 import Data.Map qualified as M
 import Test.Hspec (it, shouldBe, shouldSatisfy)
+import Test.Hspec.QuickCheck (prop)
 import Test.Tasty hiding (after_)
 import Test.Tasty.Hspec
 
@@ -76,6 +77,17 @@ configLoadingSpec =
           , LCEEnvVarParseError "SLACK_TZ_CACHE_USERS_INFO" _
           ] -> True
         _ -> False
+    prop "maxRetries validation" $ \maxRetries -> do
+      let env = M.fromList $
+            [ (botTokenEnv, "bot-token")
+            , (appTokenEnv, "app-token")
+            , (maxRetriesEnv, show (maxRetries :: Int))
+            ]
+      eithConfig <- readConfigWithEnv env (Just "config/config.yaml")
+      eithConfig `shouldSatisfy` \case
+        Left
+          [LCEInvalidValue "maxRetries" "Must be in range from 0 to 3"] -> maxRetries < 0 || maxRetries > 3
+        _ -> maxRetries >= 0 && maxRetries <=3
     it "should succeed with the valid config file and the environment containing only secrets" $ do
       let env = M.fromList $
             [ (botTokenEnv, "bot-token")

--- a/test/Test/TzBot/HandleTooManyRequests.hs
+++ b/test/Test/TzBot/HandleTooManyRequests.hs
@@ -1,0 +1,99 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module Test.TzBot.HandleTooManyRequests (test_HandleTooManyRequests) where
+
+import Universum
+
+import Data.Sequence qualified as Seq
+import Data.Time.Clock (diffUTCTime, getCurrentTime, nominalDiffTimeToSeconds)
+import Network.HTTP.Types.Header (Header)
+import Network.HTTP.Types.Method (methodGet)
+import Network.HTTP.Types.Status (status429)
+import Network.HTTP.Types.Version (http11)
+import Servant.Client.Core
+  (BaseUrl(BaseUrl), ClientError(FailureResponse), RequestF(Request), ResponseF(Response),
+  Scheme(Https))
+import Test.Tasty (TestTree, localOption)
+
+import Data.Fixed (Fixed(MkFixed))
+import Test.QuickCheck.Monadic (assert, monadicIO, run)
+import Test.Tasty.QuickCheck
+  (Arbitrary(arbitrary), Property, QuickCheckTests(QuickCheckTests), choose, generate, testProperty)
+import TzBot.Slack (handleTooManyRequests)
+
+-- | Delay between attempts in seconds
+newtype Delay = Delay {unDelay :: Double} deriving stock (Show)
+
+-- | Number of attempts to call slack api
+newtype Attempts = Attempts {unAttempts :: Int} deriving stock (Show)
+
+instance Arbitrary Delay where
+  arbitrary = Delay <$> choose (0.5, 1)
+
+instance Arbitrary Attempts where
+  arbitrary = Attempts <$> choose (1, 3)
+
+-- | Mutable test state
+data TestState = TestState
+  {
+    attempts :: Int  -- ^ The number of attempts left
+  , delay :: Double  -- ^ Sum of delays during every attempt
+  }
+
+test_HandleTooManyRequests :: TestTree
+test_HandleTooManyRequests =
+  localOption (QuickCheckTests 10) $
+  testProperty "Handle Too Many Requests" handleTooManyRequestsProperty
+
+-- | Property function of handling of slack API response 429 @Too many request@
+-- It works as follows:
+--
+-- 1. For arbitrary number of attempts it runs `handleTooManyRequests` with mock of
+-- slack request computation.
+-- 2. Fixes the time the computation takes.
+-- 3. The time of computation should be not less the sum of delays in every attempt.
+handleTooManyRequestsProperty :: Attempts -> Property
+handleTooManyRequestsProperty attempts = monadicIO $ do
+  let attempts' = unAttempts attempts
+  stateRef <- newIORef $ TestState attempts' 0
+  start <- run getCurrentTime
+  run $ evalStateT (handleTooManyRequests $ mockSlackRequest stateRef) attempts'
+  end <- run getCurrentTime
+  delay' <- delay <$> readIORef stateRef
+  let realDelay = nominalDiffTimeToSeconds $ diffUTCTime end start
+      expectedDelay = MkFixed ((ceiling (delay' * 10^(12 :: Int))))
+  assert (realDelay >= expectedDelay)
+
+-- | Mock for slack API request.
+-- It uses the value of attempts from test state to emulate behavour of slack API.
+-- While the number of left attempts is greater than zero it responses with status
+-- 429 'Too many requests' with arbitrary @Retry-After@ header value of `Delay`.
+-- After this it returns success.
+mockSlackRequest :: IORef TestState -> IO (Either ClientError ())
+mockSlackRequest stateRef = do
+  attempts' <- attempts <$> readIORef stateRef
+  if attempts' == 0
+    then return $ Right ()
+    else do
+        delay' <- generate arbitrary :: IO Delay
+        modifyIORef
+          stateRef
+          (\st -> st {attempts = attempts' - 1, delay = delay st + unDelay delay'})
+        return $ Left (failureResponse delay')
+  where
+    failureResponse :: Delay -> ClientError
+    failureResponse delay = FailureResponse request response
+      where
+        request = Request
+                (BaseUrl Https "host" 80 "", "")
+                Seq.empty
+                Nothing
+                Seq.empty
+                Seq.empty
+                http11
+                methodGet
+                :: RequestF () (BaseUrl, ByteString)
+        headers = Seq.singleton ("retry-after", show . unDelay $ delay) :: Seq Header
+        response = Response status429 headers http11 ""

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -125,8 +125,6 @@ library
     , tz
     , tztime
     , universum
-    , uri-bytestring
-    , uri-bytestring-aeson
     , utf8-string
     , validation
     , yaml

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -103,6 +103,7 @@ library
     , formatting
     , http-client
     , http-client-tls
+    , http-types
     , lifted-async
     , megaparsec
     , monad-control
@@ -112,6 +113,7 @@ library
     , servant-auth
     , servant-auth-client
     , servant-client
+    , servant-client-core
     , servant-server
     , slacker
     , string-conversions
@@ -123,6 +125,9 @@ library
     , tz
     , tztime
     , universum
+    , uri-bytestring
+    , uri-bytestring-aeson
+    , utf8-string
     , validation
     , yaml
   default-language: Haskell2010
@@ -196,6 +201,7 @@ test-suite tzbot-test
   main-is: Main.hs
   other-modules:
       Test.TzBot.ConfigSpec
+      Test.TzBot.HandleTooManyRequests
       Test.TzBot.TimeReferenceToUtcSpec
       Tree
       Paths_tzbot
@@ -256,12 +262,16 @@ test-suite tzbot-test
   build-tool-depends:
       tasty-discover:tasty-discover
   build-depends:
-      base >=4.7 && <5
+      QuickCheck
+    , base >=4.7 && <5
     , containers
     , hspec
+    , http-types
+    , servant-client-core
     , tasty
     , tasty-hspec
     , tasty-hunit
+    , tasty-quickcheck
     , time
     , tzbot
     , tztime


### PR DESCRIPTION
## Description

Problem: Sometimes slack can respond with status 429 Too Many Requests.
We have to handle this and take a try to request the slack api again
after the delay set in Retry-After header.

Solution: Wrap enent handler with function which detects the response
with status code 429, extracts the delay from headers and runs again the
event handler after the delay. The number of attempts is defined in bot
configuration.

## Related issue(s)

Fixed #5 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [X] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [X] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [X] My code complies with the [style guide](../tree/master/docs/code-style.md).
