### PR TITLE
[Fix] Remove redundant  `BotConfig` datatype

### DIFF
--- a/src/TzBot/Config/Types.hs
+++ b/src/TzBot/Config/Types.hs
@@ -37,6 +37,8 @@ type family ConfigField (k :: ConfigStage) a where
   ConfigField 'CSInterm a = Maybe a
   ConfigField 'CSFinal a = a
 
+type BotConfig = Config 'CSFinal
+
 appTokenEnv, botTokenEnv, maxRetriesEnv, cacheUsersEnv, cacheConvMembersEnv :: EnvVarName
 appTokenEnv = "SLACK_TZ_APP_TOKEN"
 botTokenEnv = "SLACK_TZ_BOT_TOKEN"

--- a/src/TzBot/RunMonad.hs
+++ b/src/TzBot/RunMonad.hs
@@ -20,11 +20,6 @@ import TzBot.Config
 import TzBot.Slack.API
 import TzBot.TimeReference
 
-data BotConfig = BotConfig
-  { bcAppLevelToken :: AppLevelToken
-  , bcBotToken :: BotToken
-  }
-
 data BotState = BotState
   { bsConfig :: BotConfig
   , bsManager :: Manager

--- a/src/TzBot/Slack.hs
+++ b/src/TzBot/Slack.hs
@@ -9,7 +9,7 @@ module TzBot.Slack
   , AppLevelToken(..)
   , BotToken(..)
   , BotState(..)
-  , BotConfig(..)
+  , BotConfig
   , BotException(..)
   , getUser
   , getChannelMembers
@@ -20,13 +20,13 @@ import Universum
 
 import Control.Monad.Except (throwError)
 import Data.Aeson (Value)
+import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Servant ((:<|>)(..))
 import Servant.Auth.Client qualified as Auth
 import Servant.Client
   (BaseUrl(BaseUrl), ClientM, Scheme(Https), client, hoistClient, mkClientEnv, runClientM)
 
-import Data.Text qualified as T
 import TzBot.Config
 import TzBot.RunMonad
 import TzBot.Slack.API
@@ -52,7 +52,7 @@ sendEphemeralMessage channelId threadId text userId = do
 
 getBotToken :: BotM Auth.Token
 getBotToken = do
-  BotToken bt <- asks $ bcBotToken . bsConfig
+  BotToken bt <- asks $ cBotToken . bsConfig
   pure $ Auth.Token $ T.encodeUtf8 bt
 
 endpointFailed :: Text -> SlackResponse key a -> BotM a


### PR DESCRIPTION
## Description

Problem: datatype `BotConfig` was redundant.

Solution: use `Config` instead.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #6 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
