### PR TITLE
[#32] Add CLI options parsing

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -23,9 +23,11 @@ library:
   - aeson
   - aeson-casing
   - base >= 4.7 && < 5
+  - bytestring
   - cache
   - clock
   - containers
+  - directory
   - fmt
   - dlist
   - formatting
@@ -40,6 +42,7 @@ library:
   - nyan-interpolation
   - o-clock
   - random
+  - optparse-applicative
   - servant-auth
   - servant-auth-client
   - servant-client

--- a/src/TzBot/Options.hs
+++ b/src/TzBot/Options.hs
@@ -1,0 +1,66 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module TzBot.Options where
+
+import Universum
+
+import Options.Applicative
+
+data Command
+  = DefaultCommand Options
+  | DumpConfig DumpOptions
+
+data DumpOptions
+  = DOStdOut
+  | DOFile FilePath Bool
+
+data Options = Options
+  { oConfigFile :: Maybe FilePath
+  }
+
+totalParser :: ParserInfo Command
+totalParser = info (commandParserWithDefault <**> helper) $
+  mconcat
+  [ fullDesc
+  , progDesc
+      "Perform time references translation on new messages post to \
+       \Slack conversations or on direct user triggers."
+  , header "Slack timezone bot"
+  , footer configAndEnvironmentNote
+  ]
+
+commandParserWithDefault :: Parser Command
+commandParserWithDefault = asum
+  [ commandParser
+  , DefaultCommand <$> optionsParser
+  ]
+
+commandParser :: Parser Command
+commandParser = hsubparser $
+  command "dump-config" $
+    info (DumpConfig <$> dumpOptionsParser) (progDesc "Dump default config")
+
+dumpOptionsParser :: Parser DumpOptions
+dumpOptionsParser = asum [stdoutParser, dumpFileParser]
+  where
+    stdoutParser = flag' DOStdOut $ long "stdout" <> help "Standart output"
+    dumpFileParser = DOFile <$> strOption fileOption <*> forceOption
+    fileOption :: Mod OptionFields FilePath
+    fileOption = (long "file" <> short 'f' <> metavar "FILEPATH" <> help "Dump to file FILEPATH")
+    forceOption = switch (long "force" <> help "Whether to overwrite existing file")
+
+optionsParser :: Parser Options
+optionsParser = Options <$> do
+  optional $
+    strOption
+      (long "config" <> short 'c' <> metavar "FILEPATH" <> help "Load configuration from FILEPATH")
+
+configAndEnvironmentNote :: String
+configAndEnvironmentNote =
+  "Configuration parameters can be also specified using environment\
+  \ variables, for details run `tzbot dump-config -f <filepath>` and\
+  \ see the config fields descriptions. If all the parameters are contained\
+  \ by either envvars or the default config, the additional config file is\
+  \ not required."

--- a/test/Test/TzBot/ConfigSpec.hs
+++ b/test/Test/TzBot/ConfigSpec.hs
@@ -9,7 +9,7 @@ module Test.TzBot.ConfigSpec (
 import Universum
 
 import Data.Map qualified as M
-import Test.Hspec (it, shouldBe, shouldSatisfy)
+import Test.Hspec (expectationFailure, it, shouldSatisfy)
 import Test.Hspec.QuickCheck (prop)
 import Test.Tasty hiding (after_)
 import Test.Tasty.Hspec (testSpec)
@@ -28,7 +28,11 @@ defaultConfigSpec =
   testSpec "Default config" $ do
     it "config/config.yaml should be the same as the default config" $ do
       contents <- (readFile "config/config.yaml" :: IO Text)
-      contents `shouldBe` decodeUtf8 defaultConfigText
+      when (contents /= decodeUtf8 defaultConfigText) $
+        expectationFailure
+          "config/config.yaml should be the same as the default config,\
+            \ please run `stack exec tzbot-exe -- dump-config --file\
+            \ config/config.yaml --force"
 
 configLoadingSpec :: IO TestTree
 configLoadingSpec =

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -30,6 +30,7 @@ library
       TzBot.Config.Default
       TzBot.Config.Types
       TzBot.Instances
+      TzBot.Options
       TzBot.Parser
       TzBot.ProcessEvent
       TzBot.RunMonad
@@ -99,9 +100,11 @@ library
       aeson
     , aeson-casing
     , base >=4.7 && <5
+    , bytestring
     , cache
     , clock
     , containers
+    , directory
     , dlist
     , fmt
     , formatting
@@ -115,6 +118,7 @@ library
     , mtl
     , nyan-interpolation
     , o-clock
+    , optparse-applicative
     , random
     , servant-auth
     , servant-auth-client


### PR DESCRIPTION
## Description
Problem: Currently, our program has no CLI infrastructure with program
  description, helps etc. Also, there is no way to dump the default
  config with useful explanations.

Solution: Add optparse-applicative CLI parser that supports the default
  mode (run the Slack timezone bot) and also additional dump-config
  command.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #32 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
