### PR TITLE
[#35] Fetch user info concurrently

### DIFF
--- a/src/TzBot/ProcessEvent.hs
+++ b/src/TzBot/ProcessEvent.hs
@@ -94,14 +94,15 @@ processMessageEvent evt = when (newMessageOrEditedMessage evt) $ do
     let notBotAndSameTimeZone u = not (uIsBot u) && uTz u /= uTz sender
         notSender userId = userId /= uId sender
 
-    usersToNotify <- filter notBotAndSameTimeZone
-      <$> (mapM getUserCached $ filter notSender $ S.toList usersInChannelIds)
---    usersToNotify <- mapM getUserCached $ S.toList usersInChannelIds -- dev
-
-    forConcurrently_ usersToNotify $ \userToNotify -> do
-      let ephemeralMessage =
-            renderEphemeralMessageForOthers userToNotify ephemeralTemplate
-      sendAction ephemeralMessage (uId userToNotify)
+    forConcurrently_ usersInChannelIds $ \userInChannelId ->
+      when (notSender userInChannelId) $ do
+--      when True $ do -- dev
+        userInChannel <- getUserCached userInChannelId
+--        when True $ do -- dev
+        when (notBotAndSameTimeZone userInChannel) $ do
+          let ephemeralMessage =
+                renderEphemeralMessageForOthers userInChannel ephemeralTemplate
+          sendAction ephemeralMessage (uId userInChannel)
 
 processMemberJoinedChannel :: MemberJoinedChannelEvent -> BotM ()
 processMemberJoinedChannel MemberJoinedChannelEvent {..} = do


### PR DESCRIPTION
## Description
Problem: Currently, we run getUser sequentially on all the users of the channel, and that may cause large delays.

Solution: Put `getUserInfoCached` and `sendEphemeralMessage` in separate thread.



<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #35 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
