### PR TITLE
[#38] Ignore time references in code blocks

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ library:
   - universum
   - aeson
   - aeson-casing
+  - aeson-pretty
   - base >= 4.7 && < 5
   - bytestring
   - cache
@@ -29,7 +30,9 @@ library:
   - containers
   - directory
   - fmt
+  - deriving-aeson
   - dlist
+  - fmt
   - formatting
   - guid
   - http-client
@@ -56,6 +59,7 @@ library:
   - text
   - time
   - time-compat
+  - transformers
   - transformers-base
   - tz
   - tztime
@@ -88,20 +92,22 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - base >= 4.7 && < 5
+    - universum
     - tzbot
+    - aeson
     - containers
     - hspec
+    - http-types
+    - nyan-interpolation
+    - servant-client-core
+    - string-conversions
     - tasty
     - tasty-hspec
     - tasty-hunit
+    - tasty-quickcheck
     - time
     - tztime
     - QuickCheck
-    - http-types
-    - servant-client-core
-    - tasty-quickcheck
-    - time
-    - universum
   doctests:
     main:                doctests.hs
     source-dirs:         test

--- a/src/TzBot/ProcessEvents/Common.hs
+++ b/src/TzBot/ProcessEvents/Common.hs
@@ -4,18 +4,31 @@
 
 module TzBot.ProcessEvents.Common
   ( openModalCommon
+  , getTimeReferencesFromMessage
+
+    -- * exported for tests
+  , ignoreCodeBlocksManually
   ) where
 
 import Universum
 
+import Data.Aeson.Encode.Pretty (encodePrettyToTextBuilder)
 import Data.GUID (genText)
+import Data.Text qualified as T
+import Fmt (listF)
+import Text.Interpolation.Nyan (int, rmode')
 
 import TzBot.Feedback.Dialog (insertDialogEntry)
 import TzBot.Feedback.Dialog.Types
 import TzBot.Parser (parseTimeRefs)
 import TzBot.Render (TranslationPairs, renderAllForOthersTP, renderTemplate)
+import TzBot.RunMonad (log')
 import TzBot.Slack (BotM, getUserCached, startModal)
 import TzBot.Slack.API
+import TzBot.Slack.API.MessageBlock
+  (UnknownBlockElementLevel2Error(ubeType), extractPieces, splitExtractErrors)
+import TzBot.TimeReference (TimeReference)
+import TzBot.Util (WithUnknown(unUnknown))
 
 -- | Generic function that starts view or report modal where
 --   time references translations can be viewed
@@ -32,7 +45,7 @@ openModalCommon
 openModalCommon message channelId whoTriggeredId triggerId mkModalFunc = do
   let msgText = mText message
       msgTimestamp = mTs message
-  let mbTimeRefs = nonEmpty $ parseTimeRefs $ mText message
+  mbTimeRefs <- nonEmpty <$> getTimeReferencesFromMessage message
   sender <- getUserCached $ mUser message
   translationPairs <- forM mbTimeRefs $ \neTimeRefs -> do
       whoTriggered <- getUserCached whoTriggeredId
@@ -53,3 +66,59 @@ openModalCommon message channelId whoTriggeredId triggerId mkModalFunc = do
   insertDialogEntry guid metadata
   let modal = mkModalFunc msgText translationPairs guid
   startModal $ OpenViewReq modal triggerId
+
+-- | Extract separate text pieces from the Slack message that can contain
+-- the whole time reference and try to find time references inside them.
+getTimeReferencesFromMessage
+  :: Message
+  -> BotM [TimeReference]
+getTimeReferencesFromMessage message =
+  concatMap parseTimeRefs <$> getTextPiecesFromMessage message
+
+-- | Extract separate text pieces from the Slack message that can contain
+-- the whole time reference. The main way is analyzing the message's block
+-- structure, but since it's not documented it can not work sometimes,
+-- `ignoreCodeBlocksManually` is used a reserve function.
+getTextPiecesFromMessage
+  :: Message
+  -> BotM [Text]
+getTextPiecesFromMessage message = do
+  let throwAwayTooShort = filter (\x -> T.compareLength x 2 == GT)
+  throwAwayTooShort <$> case unUnknown $ msgBlocks message of
+    Left unknownBlocksValue -> do
+      log' [int||warning: Failed to parse message blocks, \
+                 trying to ignore code blocks manually|]
+      log' [int||warning: Unrecognized message blocks: \
+                 #{encodePrettyToTextBuilder unknownBlocksValue}|]
+      pure $ ignoreCodeBlocksManually $ mText message
+    Right blocks -> do
+      let (pieces, exErrs) = extractPieces blocks
+      let (l1Errs, l2Errs) = splitExtractErrors exErrs
+      when (not $ null l1Errs) $
+        log' [int||warning: Unknown level1 block types: #{listF $ map (show @Text) l1Errs}|]
+      when (not $ null l2Errs) $
+        log' [int||warning: Unknown level2 block types: #{listF $ map ubeType l2Errs}|]
+      pure pieces
+
+{- | Simple function that works in a very naive way, but it's just reserve
+ - option when Slack blocks can't be parsed.
+ -}
+ignoreCodeBlocksManually :: Text -> [Text]
+ignoreCodeBlocksManually txt =
+  concatMap (splitByCodeBlocks simpleCodeDelimiter) $
+    splitByCodeBlocks codeBlockDelimiter txt
+  where
+  codeBlockDelimiter = "```"
+  simpleCodeDelimiter = "`"
+
+  splitByCodeBlocks :: Text -> Text -> [Text]
+  splitByCodeBlocks _ "" = []
+  splitByCodeBlocks delim txt = do
+    let (xs, ys) = T.breakOn delim txt
+    case T.stripPrefix delim ys of
+      Nothing -> [xs]
+      Just ys' -> do
+        let (_ignored, zs) = T.breakOn delim ys'
+        case T.stripPrefix delim zs of
+          Nothing -> [txt]
+          Just zs' -> xs : splitByCodeBlocks delim zs'

--- a/src/TzBot/ProcessEvents/Message.hs
+++ b/src/TzBot/ProcessEvents/Message.hs
@@ -15,7 +15,7 @@ import Data.Set qualified as S
 import System.Random (randomRIO)
 
 import TzBot.Config (Config(..))
-import TzBot.Parser (parseTimeRefs)
+import TzBot.ProcessEvents.Common (getTimeReferencesFromMessage)
 import TzBot.Render
 import TzBot.RunMonad (log')
 import TzBot.Slack
@@ -84,9 +84,10 @@ processMessageEvent evt = when (newMessageOrEditedMessage evt) $ do
   let msg = meMessage evt
 
   -- TODO: use some "transactions here"? Or just lookup the map multiple times.
+  timeRefs <- getTimeReferencesFromMessage msg
   mbReferencesToCheck <-
-    filterNewReferencesAndMemorize (mMessageId msg) (parseTimeRefs $ mText msg)
-  whenJust mbReferencesToCheck $ \timeRefs -> do
+    filterNewReferencesAndMemorize (mMessageId msg) timeRefs
+  whenJust mbReferencesToCheck $ \timeRefs-> do
     inverseChance <- asks $ cInverseHelpUsageChance . bsConfig
     sender <- getUserCached $ mUser msg
 

--- a/src/TzBot/Slack/API.hs
+++ b/src/TzBot/Slack/API.hs
@@ -46,6 +46,7 @@ import Text.Interpolation.Nyan (int, rmode')
 import TzBot.Instances ()
 import TzBot.Slack.API.Block
 import TzBot.Slack.API.Common
+import TzBot.Slack.API.MessageBlock (MessageBlock)
 import TzBot.Util
 
 ----------------------------------------------------------------------------
@@ -218,6 +219,7 @@ data Message = Message
   , mThreadId :: Maybe ThreadId
   , mEdited :: Bool
   , mSubType :: Maybe Text
+  , msgBlocks :: WithUnknown [MessageBlock]
   } deriving stock (Eq, Show, Generic)
 
 instance FromJSON Message where
@@ -233,6 +235,7 @@ parseMessage o = do
   mSubType <- o .:? "subtype"
   mEdited <- fmap (isJust @Text) . runMaybeT $
     MaybeT (o .:? "edited") >>= MaybeT . (.:? "ts")
+  msgBlocks <- o .: "blocks"
   pure Message {..}
 
 -- | See: https://api.slack.com/types/user

--- a/src/TzBot/Slack/API/MessageBlock.hs
+++ b/src/TzBot/Slack/API/MessageBlock.hs
@@ -1,0 +1,169 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+{- | This module contains datatypes that are used to parse the message blocks
+ - that the message objects are shipped with. They seem to be not properly
+ - documented and we have to be safe and assume that some unknown objects
+ - can appear.
+ - See:
+ - * https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
+ - * https://api.slack.com/reference/messaging/payload
+ -}
+module TzBot.Slack.API.MessageBlock
+  ( -- * Block datatype
+    MessageBlock
+
+    -- * Extract errors (or, more precisely, warnings)
+  , ExtractError (..)
+  , UnknownBlockElementLevel1Type (..)
+  , UnknownBlockElementLevel2Error (..)
+
+    -- * Functions
+  , extractPieces
+  , splitExtractErrors
+  ) where
+
+import Universum
+
+import Control.Monad.Trans.Writer.CPS (Writer, runWriter, tell)
+import Data.Aeson
+  (FromJSON(..), Options(..), SumEncoding(..), ToJSON(toJSON), Value, camelTo2, defaultOptions,
+  genericParseJSON, genericToJSON)
+import Data.Aeson.Lens (AsPrimitive(_String), key)
+import Data.Char (isLower)
+import Data.String.Conversions (cs)
+import Data.Text.Internal.Builder (Builder, fromText, toLazyText)
+import Deriving.Aeson (CamelToSnake, ConstructorTagModifier, CustomJSON(..), StripPrefix)
+
+import TzBot.Util
+
+newtype MessageBlock = MessageBlock
+  { mbElements :: [BlockElementLevel1]
+  } deriving stock (Eq, Show, Generic)
+    deriving (FromJSON, ToJSON) via RecordWrapper MessageBlock
+
+data BlockElementLevel1
+  = BEL1List RichTextList
+  | BEL1Plain PlainBlockElementLevel1
+    deriving stock (Eq, Show, Generic)
+    deriving (FromJSON, ToJSON) via SumWrapper BlockElementLevel1
+
+data RichTextList = RichTextList
+  { rtlElements :: [BlockElementLevel1]
+  } deriving stock (Eq, Show, Generic)
+    deriving (FromJSON, ToJSON) via TypedWrapper RichTextList
+
+data BlockElementType
+  = BETRichTextSection -- ^ Simple text section
+  | BETRichTextPreformatted -- ^ Multiline code block
+  | BETRichTextQuote -- ^ Slack quote
+  deriving stock (Eq, Show, Generic)
+  deriving (FromJSON, ToJSON) via CustomJSON '[ConstructorTagModifier '[StripPrefix "BET", CamelToSnake]] BlockElementType
+
+data PlainBlockElementLevel1 = PlainBlockElementLevel1
+  { beType     :: WithUnknown BlockElementType
+  , beElements :: Maybe [WithUnknown ElementText]
+    -- ^ Level 2 elements
+  } deriving stock (Eq, Show, Generic)
+    deriving (FromJSON, ToJSON) via RecordWrapper PlainBlockElementLevel1
+
+----
+data Style = Style
+  { styCode   :: Maybe Bool
+  , styStrike :: Maybe Bool
+  , styItalic :: Maybe Bool
+  , styBold   :: Maybe Bool
+  } deriving stock (Eq, Show, Generic)
+    deriving (FromJSON, ToJSON) via RecordWrapper Style
+
+--
+-- | Here it's the only level 2 element because we are not interested
+-- in others at the current moment.
+data ElementText = ElementText
+  { etText  :: Text
+  , etStyle :: Maybe Style
+  } deriving stock (Eq, Show, Generic)
+
+blockElementOptions :: Options
+blockElementOptions = defaultOptions
+  { fieldLabelModifier = camelTo2 '_' . dropWhile isLower
+  , constructorTagModifier = camelTo2 '_' . stripPrefixIfPresent "Element"
+  , tagSingleConstructors = True
+  , sumEncoding = TaggedObject "type" "contents"
+  , omitNothingFields = True
+  }
+
+instance FromJSON ElementText where
+  parseJSON = genericParseJSON blockElementOptions
+
+instance ToJSON ElementText where
+  toJSON = genericToJSON blockElementOptions
+
+----
+data ExtractError
+  = EEUnknownBlockElementLevel1Type UnknownBlockElementLevel1Type
+  | EEUnknownBlockElementLevel2 UnknownBlockElementLevel2Error
+  deriving stock (Eq, Show)
+
+splitExtractErrors
+  :: [ExtractError]
+  -> ([UnknownBlockElementLevel1Type], [UnknownBlockElementLevel2Error])
+splitExtractErrors = partitionEithers . map f
+  where
+  f (EEUnknownBlockElementLevel1Type val) = Left val
+  f (EEUnknownBlockElementLevel2 l2Val) = Right l2Val
+
+newtype UnknownBlockElementLevel1Type = UnknownBlockElementLevel1Type
+  { ubeltValue :: Value
+  } deriving stock (Eq, Show)
+
+data UnknownBlockElementLevel2Error = UnknownBlockElementLevel2Error
+  { ubeType  :: Text
+  , ubeValue :: Value
+  } deriving stock (Eq, Show)
+
+-- | This function has two main tasks:
+-- 1. Analyze the Slack-provided structure of the incoming message;
+-- 2. Ignore code blocks.
+--
+-- Also since the message blocks are not documented, it collects unrecognized
+-- values of level1/level2 block elements.
+extractPieces :: [MessageBlock] -> ([Text], [ExtractError])
+extractPieces mBlocks = runWriter $ concat <$> mapM goMessageBlock mBlocks
+  where
+  goMessageBlock :: MessageBlock -> Writer [ExtractError] [Text]
+  goMessageBlock MessageBlock {..} = concat <$> mapM goBlockElementLevel1 mbElements
+
+  goBlockElementLevel1 :: BlockElementLevel1 -> Writer [ExtractError] [Text]
+  goBlockElementLevel1 = \case
+    BEL1List RichTextList {..} -> concat <$> mapM goBlockElementLevel1 rtlElements
+    BEL1Plain PlainBlockElementLevel1 {..} -> do
+      whenLeft (unUnknown beType) \val ->
+        tell [EEUnknownBlockElementLevel1Type $ UnknownBlockElementLevel1Type val]
+      -- ignore multiline code block
+      case beType of
+        WithUnknown (Right BETRichTextPreformatted) -> pure []
+        _ -> maybe (pure []) goBlockElementLevel2 beElements
+
+  goBlockElementLevel2 :: [WithUnknown ElementText] -> Writer [ExtractError] [Text]
+  goBlockElementLevel2 els = reverse <$> go Nothing [] els
+    where
+    go :: Maybe Builder -> [Text] -> [WithUnknown ElementText] -> Writer [ExtractError] [Text]
+    go mbCurPiece prevPieces (e:es) = case unUnknown e of
+      Left val -> do
+        let _type = fromMaybe "unknown" (val ^? key "type" . _String)
+        tell [EEUnknownBlockElementLevel2 $ UnknownBlockElementLevel2Error _type val]
+        go Nothing (prependMbCurrentToPrevious mbCurPiece prevPieces) es
+      Right ElementText {..} -> do
+        let etTextB = fromText etText
+        if (etStyle >>= styCode) == Just True
+          -- ignore simple code block
+          then go Nothing (prependMbCurrentToPrevious mbCurPiece prevPieces) es
+          else go (Just $ maybe etTextB (<> etTextB) mbCurPiece) prevPieces es
+    go mbCurPiece prevPieces [] =
+      pure $ prependMbCurrentToPrevious mbCurPiece prevPieces
+
+    prependMbCurrentToPrevious :: Maybe Builder -> [Text] -> [Text]
+    prependMbCurrentToPrevious mbCurPiece prevPieces =
+      maybe prevPieces ((: prevPieces) . cs . toLazyText) mbCurPiece

--- a/test/Test/TzBot/MessageBlocksSpec.hs
+++ b/test/Test/TzBot/MessageBlocksSpec.hs
@@ -1,0 +1,409 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module Test.TzBot.MessageBlocksSpec
+  ( test_messageBlocksSpec
+  , test_ignoreManuallySpec
+  ) where
+
+import Universum
+
+import Data.Aeson (decode)
+import Data.Maybe (fromJust)
+import Data.String.Conversions
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Test.Tasty.Runners (TestTree(..))
+import Text.Interpolation.Nyan
+
+import TzBot.ProcessEvents.Common (ignoreCodeBlocksManually)
+import TzBot.Slack.API.MessageBlock
+
+getLevel2Errors :: [ExtractError] -> [Text]
+getLevel2Errors = mapMaybe f
+  where
+  f EEUnknownBlockElementLevel1Type {} = Nothing
+  f (EEUnknownBlockElementLevel2 l2Err) = Just $ ubeType l2Err
+
+test_ignoreManuallySpec :: TestTree
+test_ignoreManuallySpec = TestGroup "Test `ignoreCodeBlocksManually`" $
+  [ testCase "two big blocks" $ do
+      let res = ignoreCodeBlocksManually "asd ```big code block1``` qwe ``` big code block2 ``` fda"
+      res @?= ["asd "," qwe "," fda"]
+  , testCase "bad big block" $ do
+      let res = ignoreCodeBlocksManually "asd ```big code block1``` qwe ``` bad block"
+      res @?= ["asd "," qwe ","` bad block"]
+  , testCase "little and big blocks" $ do
+      let res = ignoreCodeBlocksManually "asd `little block` ```big code block1 ```"
+      res @?= ["asd "," "]
+  , testCase "big and little blocks" $ do
+      let res = ignoreCodeBlocksManually "``` code ``` foo `bar` baz"
+      res @?= [" foo "," baz"]
+  ]
+
+test_messageBlocksSpec :: TestTree
+test_messageBlocksSpec = TestGroup "Message blocks" $
+  [ testCase "Correct extraction of all text pieces ignoring code blocks" $ do
+      let justEverything = fromJust $ decode $ cs justEverythingRaw
+          res = extractPieces justEverything
+      fst res @?=
+        [ "1plain "
+        , " 1strike "
+        , " bold 1strikeditalic\n"
+        , "3.1quote block "
+        , " 3.2quote block"
+        , "4.1plain "
+        , " 4.1strike "
+        , " 4.1bold "
+        , "4.2plain "
+        , " 4.2strike "
+        , "  4.2bold "
+        , "between the lists\n"
+        , "5.1plain "
+        , " 5.1strike "
+        , " 5.1bold"
+        , "5.2something "
+        , " 10am "
+        , " 10"
+        , "am I a human?"
+        , "end!"
+        ]
+      getLevel2Errors (snd res) @?=
+        [ "emoji", "link", "user", "broadcast"
+        ]
+  ]
+
+{- | The original Slack message:
+1plain `code` ~1strike~ `code` *bold* ~_1strikeditalic_~
+```2big code block```
+&gt; 3.1quote block `code` 3.2quote block
+1. 4.1plain `code` ~4.1strike~ :slightly_smiling_face: *4.1bold*
+2. 4.2plain `code` ~4.2strike~ <http://github.com|github>  *4.2bold*
+between the lists
+\8226 5.1plain `code` 5~.1strike~ `code` 5*.1bold*
+\8226 5.2something <@U04FQH806E9> 10am <!here> 10
+\8226 am I a human?
+end!
+ -}
+justEverythingRaw :: ByteString
+justEverythingRaw = [int||
+[
+    {
+        "block_id": "tH8as",
+        "elements": [
+            {
+                "elements": [
+                    {
+                        "text": "1plain ",
+                        "type": "text"
+                    },
+                    {
+                        "style": {
+                            "code": true
+                        },
+                        "text": "code",
+                        "type": "text"
+                    },
+                    {
+                        "text": " ",
+                        "type": "text"
+                    },
+                    {
+                        "style": {
+                            "strike": true
+                        },
+                        "text": "1strike",
+                        "type": "text"
+                    },
+                    {
+                        "text": " ",
+                        "type": "text"
+                    },
+                    {
+                        "style": {
+                            "code": true
+                        },
+                        "text": "code",
+                        "type": "text"
+                    },
+                    {
+                        "text": " ",
+                        "type": "text"
+                    },
+                    {
+                        "style": {
+                            "bold": true
+                        },
+                        "text": "bold",
+                        "type": "text"
+                    },
+                    {
+                        "text": " ",
+                        "type": "text"
+                    },
+                    {
+                        "style": {
+                            "italic": true,
+                            "strike": true
+                        },
+                        "text": "1strikeditalic",
+                        "type": "text"
+                    },
+                    {
+                        "text": "\\n",
+                        "type": "text"
+                    }
+                ],
+                "type": "rich_text_section"
+            },
+            {
+                "border": 0,
+                "elements": [
+                    {
+                        "text": "2big code block",
+                        "type": "text"
+                    }
+                ],
+                "type": "rich_text_preformatted"
+            },
+            {
+                "elements": [
+                    {
+                        "text": "3.1quote block ",
+                        "type": "text"
+                    },
+                    {
+                        "style": {
+                            "code": true
+                        },
+                        "text": "code",
+                        "type": "text"
+                    },
+                    {
+                        "text": " 3.2quote block",
+                        "type": "text"
+                    }
+                ],
+                "type": "rich_text_quote"
+            },
+            {
+                "border": 0,
+                "elements": [
+                    {
+                        "elements": [
+                            {
+                                "text": "4.1plain ",
+                                "type": "text"
+                            },
+                            {
+                                "style": {
+                                    "code": true
+                                },
+                                "text": "code",
+                                "type": "text"
+                            },
+                            {
+                                "text": " ",
+                                "type": "text"
+                            },
+                            {
+                                "style": {
+                                    "strike": true
+                                },
+                                "text": "4.1strike",
+                                "type": "text"
+                            },
+                            {
+                                "text": " ",
+                                "type": "text"
+                            },
+                            {
+                                "name": "slightly_smiling_face",
+                                "style": {
+                                    "bold": true
+                                },
+                                "type": "emoji",
+                                "unicode": "1f642"
+                            },
+                            {
+                                "text": " ",
+                                "type": "text"
+                            },
+                            {
+                                "style": {
+                                    "bold": true
+                                },
+                                "text": "4.1bold ",
+                                "type": "text"
+                            }
+                        ],
+                        "type": "rich_text_section"
+                    },
+                    {
+                        "elements": [
+                            {
+                                "text": "4.2plain ",
+                                "type": "text"
+                            },
+                            {
+                                "style": {
+                                    "code": true
+                                },
+                                "text": "code",
+                                "type": "text"
+                            },
+                            {
+                                "text": " ",
+                                "type": "text"
+                            },
+                            {
+                                "style": {
+                                    "strike": true
+                                },
+                                "text": "4.2strike",
+                                "type": "text"
+                            },
+                            {
+                                "text": " ",
+                                "type": "text"
+                            },
+                            {
+                                "text": "github",
+                                "type": "link",
+                                "url": "http://github.com"
+                            },
+                            {
+                                "text": "  ",
+                                "type": "text"
+                            },
+                            {
+                                "style": {
+                                    "bold": true
+                                },
+                                "text": "4.2bold ",
+                                "type": "text"
+                            }
+                        ],
+                        "type": "rich_text_section"
+                    }
+                ],
+                "indent": 0,
+                "style": "ordered",
+                "type": "rich_text_list"
+            },
+            {
+                "elements": [
+                    {
+                        "text": "between the lists\\n",
+                        "type": "text"
+                    }
+                ],
+                "type": "rich_text_section"
+            },
+            {
+                "border": 0,
+                "elements": [
+                    {
+                        "elements": [
+                            {
+                                "text": "5.1plain ",
+                                "type": "text"
+                            },
+                            {
+                                "style": {
+                                    "code": true
+                                },
+                                "text": "code",
+                                "type": "text"
+                            },
+                            {
+                                "text": " 5",
+                                "type": "text"
+                            },
+                            {
+                               "style": {
+                                    "strike": true
+                                },
+                                "text": ".1strike",
+                                "type": "text"
+                            },
+                            {
+                                "text": " ",
+                                "type": "text"
+                            },
+                            {
+                                "style": {
+                                    "code": true
+                                },
+                                "text": "code",
+                                "type": "text"
+                            },
+                            {
+                                "text": " 5",
+                                "type": "text"
+                            },
+                            {
+                                "style": {
+                                    "bold": true
+                                },
+                                "text": ".1bold",
+                                "type": "text"
+                            }
+                        ],
+                        "type": "rich_text_section"
+                    },
+                    {
+                        "elements": [
+                            {
+                                "text": "5.2something ",
+                                "type": "text"
+                            },
+                            {
+                                "type": "user",
+                                "user_id": "U04FQH806E9"
+                            },
+                            {
+                                "text": " 10am ",
+                                "type": "text"
+                            },
+                            {
+                                "range": "here",
+                                "type": "broadcast"
+                            },
+                            {
+                                "text": " 10",
+                                "type": "text"
+                            }
+                        ],
+                        "type": "rich_text_section"
+                    },
+                    {
+                        "elements": [
+                            {
+                                "text": "am I a human?",
+                                "type": "text"
+                            }
+                        ],
+                        "type": "rich_text_section"
+                    }
+                ],
+                "indent": 0,
+                "style": "bullet",
+                "type": "rich_text_list"
+            },
+            {
+                "elements": [
+                    {
+                        "text": "end!",
+                        "type": "text"
+                    }
+                ],
+                "type": "rich_text_section"
+            }
+        ],
+        "type": "rich_text"
+    }
+]
+
+|]

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -48,6 +48,7 @@ library
       TzBot.Slack.API
       TzBot.Slack.API.Block
       TzBot.Slack.API.Common
+      TzBot.Slack.API.MessageBlock
       TzBot.Slack.Events
       TzBot.Slack.Events.ViewPayload
       TzBot.Slack.Fixtures
@@ -113,11 +114,13 @@ library
   build-depends:
       aeson
     , aeson-casing
+    , aeson-pretty
     , base >=4.7 && <5
     , bytestring
     , cache
     , clock
     , containers
+    , deriving-aeson
     , directory
     , dlist
     , fmt
@@ -147,6 +150,7 @@ library
     , text
     , time
     , time-compat
+    , transformers
     , transformers-base
     , tz
     , tztime
@@ -290,6 +294,7 @@ test-suite tzbot-test
   other-modules:
       Test.TzBot.ConfigSpec
       Test.TzBot.HandleTooManyRequests
+      Test.TzBot.MessageBlocksSpec
       Test.TzBot.TimeReferenceToUtcSpec
       Tree
       Paths_tzbot
@@ -351,11 +356,14 @@ test-suite tzbot-test
       tasty-discover:tasty-discover
   build-depends:
       QuickCheck
+    , aeson
     , base >=4.7 && <5
     , containers
     , hspec
     , http-types
+    , nyan-interpolation
     , servant-client-core
+    , string-conversions
     , tasty
     , tasty-hspec
     , tasty-hunit


### PR DESCRIPTION
## Description
Problem: The bot should ignore time references in code blocks because they are most probably some logs or just some code quotations.

Solution: Ignore codeblocks by analyzing (undocumented) block structure of incoming Slack messages, using some simple code ignoring function when the block structure cannot be parsed.



<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #38

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
