### PR TITLE
[#44] Add help command

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -48,3 +48,9 @@ feedbackFile: feedback.log
 # Envvar: SLACK_TZ_CACHE_REPORT_DIALOG
 #
 cacheReportDialog: 1h
+
+# Inverse chance of appending help command usage hint to the ephemeral
+# message containing time translations.
+# Envvar: SLACK_TZ_INVERSE_HELP_USAGE_CHANCE
+#
+inverseHelpUsageChance: 15

--- a/manifest.yml
+++ b/manifest.yml
@@ -17,6 +17,10 @@ features:
       type: message
       callback_id: tz_report
       description: Report timezone bot working incorrectly
+  slash_commands:
+    - command: /tzhelp
+      description: Get info how the tzbot works
+      should_escape: false
 oauth_config:
   scopes:
     bot:

--- a/src/TzBot/Config.hs
+++ b/src/TzBot/Config.hs
@@ -30,7 +30,7 @@ import TzBot.Config.Default (defaultConfigTrick)
 import TzBot.Config.Types as Types
   (AppLevelToken(..), BotToken(..), Config(..), ConfigField, ConfigStage(..), Env, EnvVarName,
   FieldName, appTokenEnv, botTokenEnv, cacheConvMembersEnv, cacheReportDialogEnv, cacheUsersEnv,
-  feedbackChannelEnv, feedbackFileEnv, maxRetriesEnv)
+  feedbackChannelEnv, feedbackFileEnv, inverseHelpUsageChanceEnv, maxRetriesEnv)
 import TzBot.Instances ()
 
 data LoadConfigError
@@ -110,6 +110,7 @@ readConfigWithEnv env mbPath =
   cFeedbackChannel          <- fetchOptional feedbackChannelEnv   cFeedbackChannel
   cFeedbackFile             <- fetchOptional feedbackFileEnv      cFeedbackFile
   cCacheReportDialog        <- fetchOptional cacheReportDialogEnv cCacheReportDialog
+  cInverseHelpUsageChance   <- fetchOptional inverseHelpUsageChanceEnv cInverseHelpUsageChance
   pure Config {..}
   where
     handleFunc :: Y.ParseException -> IO (Either [LoadConfigError] $ Config 'CSFinal)

--- a/src/TzBot/Config/Default.hs
+++ b/src/TzBot/Config/Default.hs
@@ -11,7 +11,6 @@ import Universum
 
 import Text.Interpolation.Nyan (int, rmode')
 
-import TzBot.Config.Types (inverseHelpUsageChanceEnv)
 import TzBot.Config.Types qualified as CT
 import TzBot.Instances ()
 import TzBot.Util (Trick, thTrickYaml)

--- a/src/TzBot/Config/Default.hs
+++ b/src/TzBot/Config/Default.hs
@@ -11,6 +11,7 @@ import Universum
 
 import Text.Interpolation.Nyan (int, rmode')
 
+import TzBot.Config.Types (inverseHelpUsageChanceEnv)
 import TzBot.Config.Types qualified as CT
 import TzBot.Instances ()
 import TzBot.Util (Trick, thTrickYaml)
@@ -67,6 +68,12 @@ feedbackFile: feedback.log
 # Envvar: #{CT.cacheReportDialogEnv}
 #
 cacheReportDialog: 1h
+
+# Inverse chance of appending help command usage hint to the ephemeral
+# message containing time translations.
+# Envvar: #{CT.inverseHelpUsageChanceEnv}
+#
+inverseHelpUsageChance: 15
   |]
 
 -- This prevents Config.Default.defaultConfigText to be incorrect on compiling.

--- a/src/TzBot/Config/Types.hs
+++ b/src/TzBot/Config/Types.hs
@@ -43,7 +43,7 @@ type BotConfig = Config 'CSFinal
 appTokenEnv, botTokenEnv, maxRetriesEnv,
   cacheUsersEnv, cacheConvMembersEnv,
   feedbackChannelEnv, feedbackFileEnv,
-  cacheReportDialogEnv :: EnvVarName
+  cacheReportDialogEnv, inverseHelpUsageChanceEnv :: EnvVarName
 appTokenEnv = "SLACK_TZ_APP_TOKEN"
 botTokenEnv = "SLACK_TZ_BOT_TOKEN"
 maxRetriesEnv = "SLACK_TZ_MAX_RETRIES"
@@ -52,6 +52,7 @@ cacheConvMembersEnv = "SLACK_TZ_CACHE_CONVERSATION_MEMBERS"
 feedbackChannelEnv = "SLACK_TZ_FEEDBACK_CHANNEL"
 feedbackFileEnv = "SLACK_TZ_FEEDBACK_FILE"
 cacheReportDialogEnv = "SLACK_TZ_CACHE_REPORT_DIALOG"
+inverseHelpUsageChanceEnv = "SLACK_TZ_INVERSE_HELP_USAGE_CHANCE"
 
 -- | Overall config.
 data Config f = Config
@@ -71,6 +72,9 @@ data Config f = Config
     -- ^ File path to record collected user feedback.
   , cCacheReportDialog        :: Time Minute
     -- ^ How long a report dialog is valid after its opening.
+  , cInverseHelpUsageChance   :: Int
+    -- ^ 1/p, where p is chance to append help command usage
+    -- to the ephemeral message.
   } deriving stock (Generic)
 
 deriving stock instance Eq (Config 'CSInterm)

--- a/src/TzBot/ProcessEvents/BlockAction.hs
+++ b/src/TzBot/ProcessEvents/BlockAction.hs
@@ -5,7 +5,6 @@
 module TzBot.ProcessEvents.BlockAction
   ( -- * Handlers
     processReportButtonToggled
-  , processReportButtonFromEphemeral
   ) where
 
 import Universum
@@ -16,12 +15,10 @@ import Text.Interpolation.Nyan (int, rmode')
 import TzBot.Feedback.Dialog (lookupDialogEntry)
 import TzBot.Feedback.Dialog.Types
   (ReportDialogEntry(ReportDialogEntry, rpmMessageText, rpmMessageTimestamp, rpmSenderTimeZone, rpmTimeTranslation))
-import TzBot.ProcessEvents.Common (openModalCommon)
 import TzBot.RunMonad (log')
-import TzBot.Slack (BotM, retrieveOneMessage, retrieveOneMessageFromThread, updateModal)
+import TzBot.Slack (BotM, updateModal)
 import TzBot.Slack.API (UpdateViewReq(UpdateViewReq))
 import TzBot.Slack.Events
-import TzBot.Slack.Fixtures qualified as Fixtures
 import TzBot.Slack.Modal (mkReportModal)
 
 -- | User was in the view modal and now wants to report error.
@@ -37,16 +34,3 @@ processReportButtonToggled val = do
       UpdateViewReq
         (mkReportModal rpmMessageText rpmTimeTranslation metadataEntryId)
         (vId $ vaeView val)
-
--- | User wants to report error, the report modal is started.
-processReportButtonFromEphemeral
-  :: (ReportEphemeralEvent, Fixtures.MessageIdentifier)
-  -> BotM ()
-processReportButtonFromEphemeral (evt, Fixtures.MessageIdentifier {..}) = do
-  let channelId = scId $ reeChannel evt
-  msg <- case miThreadId of
-    Nothing -> retrieveOneMessage channelId miMessageId
-    Just threadId -> retrieveOneMessageFromThread channelId threadId miMessageId
-  let whoTriggeredId = suId $ reeUser evt
-      triggerId = reeTriggerId evt
-  openModalCommon msg channelId whoTriggeredId triggerId mkReportModal

--- a/src/TzBot/ProcessEvents/Command.hs
+++ b/src/TzBot/ProcessEvents/Command.hs
@@ -1,0 +1,25 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module TzBot.ProcessEvents.Command where
+
+import Universum
+
+import Slacker (SlashCommand(..), scChannelId)
+
+import TzBot.RunMonad (BotM(..))
+import TzBot.Slack (sendEphemeralMessage)
+import TzBot.Slack.API (ChannelId(..), PostEphemeralReq(..), UserId(..))
+import TzBot.Slack.Fixtures qualified as Fixtures
+
+processHelpCommand :: SlashCommand -> BotM ()
+processHelpCommand SlashCommand {..} = do
+  let postEphemeralReq = PostEphemeralReq
+        { perUser = UserId scUserId
+        , perChannel = ChannelId scChannelId
+        , perText = Fixtures.helpMessage
+        , perThreadTs = Nothing
+        , perBlocks = Nothing
+        }
+  sendEphemeralMessage postEphemeralReq

--- a/src/TzBot/ProcessEvents/Message.hs
+++ b/src/TzBot/ProcessEvents/Message.hs
@@ -23,6 +23,7 @@ import TzBot.Slack.API
 import TzBot.Slack.Events
 import TzBot.Slack.Fixtures qualified as Fixtures
 import TzBot.TimeReference (TimeReference(trText), TimeReferenceText)
+import TzBot.Util (isDevEnvironment)
 
 -- Helper function for `filterNewReferencesAndMemorize`
 filterNewReferencesAndMemorizePure
@@ -130,9 +131,8 @@ processMessageEvent evt = when (newMessageOrEditedMessage evt) $ do
         let notBotAndSameTimeZone u = not (uIsBot u) && uTz u /= uTz sender
             notSender userId = userId /= uId sender
 
-        let devEnv = False
         forConcurrently_ usersInChannelIds $ \userInChannelId ->
-          if devEnv
+          if isDevEnvironment
           then do
             userInChannel <- getUserCached userInChannelId
             let ephemeralMessage = renderAllForOthersTP userInChannel ephemeralTemplate

--- a/src/TzBot/Slack/Events.hs
+++ b/src/TzBot/Slack/Events.hs
@@ -64,7 +64,7 @@ instance FromJSON MessageEvent where
           (False, Just "thread_broadcast") ->
             pure (newMsg, MDMessageBroadcast)
           _ -> fail "expected edited message"
-      Just unknownSubtype -> fail $ "unknown subtype " <> toString unknownSubtype
+      Just _unknownSubtype -> parseMessageFromTopObject
     pure MessageEvent {..}
 
 -- | See https://api.slack.com/events/member_left_channel

--- a/src/TzBot/Util.hs
+++ b/src/TzBot/Util.hs
@@ -17,8 +17,10 @@ import Data.String.Conversions (cs)
 import Data.Time (UTCTime, defaultTimeLocale, parseTimeM)
 import Data.Yaml qualified as Y
 import GHC.Generics
+import GHC.IO (unsafePerformIO)
 import Language.Haskell.TH
 import System.Clock (TimeSpec, fromNanoSecs, toNanoSecs)
+import System.Environment (lookupEnv)
 import System.Random (randomRIO)
 import Text.Interpolation.Nyan (int, rmode')
 import Time (KnownDivRat, Nanosecond, Time, floorRat, ns, toUnit)
@@ -129,3 +131,9 @@ neConcatMap func ns = foldr1 (<>) $ fmap func ns
 >>> neConcatMap (\x -> x :| [x + 1]) $ 1 :| [2,3]
 1 :| [2,2,3,3,4]
  -}
+
+{-# NOINLINE isDevEnvironment #-}
+isDevEnvironment :: Bool
+isDevEnvironment = unsafePerformIO $ do
+  env <- lookupEnv "SLACK_TZ_DEVENV"
+  pure $ env == Just "true"

--- a/test/Test/TzBot/ConfigSpec.hs
+++ b/test/Test/TzBot/ConfigSpec.hs
@@ -46,6 +46,7 @@ configLoadingSpec =
             , (feedbackChannelEnv, "C13FQHWLQS2")
             , (feedbackFileEnv, "feedback.log")
             , (cacheReportDialogEnv, "3m")
+            , (inverseHelpUsageChanceEnv, "15")
             ]
       eithConfig <- readConfigWithEnv env (Just "config/nonexistent.yaml")
       eithConfig `shouldSatisfy` isRight

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -38,6 +38,7 @@ library
       TzBot.ProcessEvents
       TzBot.ProcessEvents.BlockAction
       TzBot.ProcessEvents.ChannelEvent
+      TzBot.ProcessEvents.Command
       TzBot.ProcessEvents.Common
       TzBot.ProcessEvents.Interactive
       TzBot.ProcessEvents.Message


### PR DESCRIPTION
## Description
Problem: Currently, each ephemeral with translations contain button which functionality doubles existing entrypoint. Because it can be annoying, we should remove it and instead give a hint to a user how to call tzbot entrypoints.

Solution: Remove buttons from ephemerals, add command /tzhelp, append the usage of that command randomly with rather low chance to ephemerals with translations.

Also done:
* Add dev mode using undocumented envvar;
* Handle messages with unknown subtype as ordinary messages.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #44, #41

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
