### PR TITLE
[#36] Express doubts in results

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -54,3 +54,9 @@ cacheReportDialog: 1h
 # Envvar: SLACK_TZ_INVERSE_HELP_USAGE_CHANCE
 #
 inverseHelpUsageChance: 15
+
+# Minimal permitted logging level.
+# Available: Debug, Info, Notice, Warning, Error, Critical, Alert, Emergency
+# Envvar: SLACK_TZ_LOG_LEVEL
+#
+logLevel: Info

--- a/package.yaml
+++ b/package.yaml
@@ -38,8 +38,11 @@ library:
   - http-client
   - http-client-tls
   - http-types
+  - katip
+  - lens
   - lens-aeson
   - lifted-async
+  - lifted-base
   - managed
   - megaparsec
   - monad-control
@@ -98,6 +101,7 @@ tests:
     - containers
     - hspec
     - http-types
+    - katip
     - nyan-interpolation
     - servant-client-core
     - string-conversions

--- a/src/TzBot/BotMain.hs
+++ b/src/TzBot/BotMain.hs
@@ -24,13 +24,13 @@ import TzBot.Cache
 import TzBot.Config
 import TzBot.Config.Default (defaultConfigText)
 import TzBot.Config.Types (BotConfig)
+import TzBot.Logger (withLogger)
 import TzBot.Options
 import TzBot.ProcessEvents (handler)
 import TzBot.RunMonad
 import TzBot.Util (withMaybe)
 
 {- |
-
 Usage:
 
 See @Config.Default.defaultConfigText@ to get what options
@@ -83,6 +83,7 @@ run opts = do
     bsReportEntries <-
       managed $ withTzCacheDefault cCacheReportDialog
     -- auto-acknowledge received messages
+    (bsLogNamespace, bsLogContext, bsLogEnv) <- managed $ withLogger cLogLevel
     liftIO $ runSocketMode sCfg $ handler BotState {..}
 
 withFeedbackConfig :: BotConfig -> (FeedbackConfig -> IO a) -> IO a

--- a/src/TzBot/Cache.hs
+++ b/src/TzBot/Cache.hs
@@ -28,9 +28,12 @@ import Data.Cache (Cache)
 import Data.Cache qualified as Cache
 import Data.Cache.Internal qualified as CacheI
 import Data.HashMap.Strict qualified as HM
+import Formatting (Buildable)
 import System.Clock (TimeSpec)
+import Text.Interpolation.Nyan
 import Time (Hour, KnownDivRat, Nanosecond, Time(..), hour, threadDelay, toUnit)
 
+import TzBot.Logger
 import TzBot.Util (multTimeSpec, randomTimeSpec, timeToTimespec, (+-))
 
 -- | This datatype uses `Cache` datatype inside, but also
@@ -122,16 +125,20 @@ insertRandomized key val TzCache {..} = do
 -- and insert the obtained value with configured expiration parameters
 -- into the cache.
 fetchWithCacheRandomized
-  :: (Eq k, Hashable k, MonadIO m)
+  :: (Eq k, Hashable k, MonadIO m, KatipContext m, Buildable k)
   => k
   -> (k -> m v)
   -> TzCache k v
   -> m v
-fetchWithCacheRandomized key fetchAction cache = do
+fetchWithCacheRandomized key fetchAction cache =
+  katipAddNamespace "cache" $ do
+  $(logTM) `debug` [int||Fetching key=#{key}|]
   mv <- liftIO $ Cache.lookup (rcCache cache) key
   case mv of
-    Just v -> pure v
+    Just v -> $(logTM) `debug` "Using cache" >> pure v
     Nothing -> do
+      $(logTM) `debug` [int||Key #{key} expired or absent: \
+                             using provided fetching action|]
       v <- fetchAction key
       insertRandomized key v cache
       pure v

--- a/src/TzBot/Config.hs
+++ b/src/TzBot/Config.hs
@@ -30,7 +30,7 @@ import TzBot.Config.Default (defaultConfigTrick)
 import TzBot.Config.Types as Types
   (AppLevelToken(..), BotToken(..), Config(..), ConfigField, ConfigStage(..), Env, EnvVarName,
   FieldName, appTokenEnv, botTokenEnv, cacheConvMembersEnv, cacheReportDialogEnv, cacheUsersEnv,
-  feedbackChannelEnv, feedbackFileEnv, inverseHelpUsageChanceEnv, maxRetriesEnv)
+  feedbackChannelEnv, feedbackFileEnv, inverseHelpUsageChanceEnv, logLevelEnv, maxRetriesEnv)
 import TzBot.Instances ()
 
 data LoadConfigError
@@ -111,6 +111,7 @@ readConfigWithEnv env mbPath =
   cFeedbackFile             <- fetchOptional feedbackFileEnv      cFeedbackFile
   cCacheReportDialog        <- fetchOptional cacheReportDialogEnv cCacheReportDialog
   cInverseHelpUsageChance   <- fetchOptional inverseHelpUsageChanceEnv cInverseHelpUsageChance
+  cLogLevel                 <- fetchOptional logLevelEnv          cLogLevel
   pure Config {..}
   where
     handleFunc :: Y.ParseException -> IO (Either [LoadConfigError] $ Config 'CSFinal)

--- a/src/TzBot/Config/Default.hs
+++ b/src/TzBot/Config/Default.hs
@@ -73,6 +73,12 @@ cacheReportDialog: 1h
 # Envvar: #{CT.inverseHelpUsageChanceEnv}
 #
 inverseHelpUsageChance: 15
+
+# Minimal permitted logging level.
+# Available: Debug, Info, Notice, Warning, Error, Critical, Alert, Emergency
+# Envvar: #{CT.logLevelEnv}
+#
+logLevel: Info
   |]
 
 -- This prevents Config.Default.defaultConfigText to be incorrect on compiling.

--- a/src/TzBot/Config/Types.hs
+++ b/src/TzBot/Config/Types.hs
@@ -10,6 +10,7 @@ import Universum
 
 import Data.Aeson (FromJSON(parseJSON), ToJSON(toJSON), genericParseJSON, genericToJSON)
 import Data.Data (Data)
+import Katip (Severity)
 import Time (Minute, Time)
 
 import TzBot.Instances ()
@@ -43,7 +44,8 @@ type BotConfig = Config 'CSFinal
 appTokenEnv, botTokenEnv, maxRetriesEnv,
   cacheUsersEnv, cacheConvMembersEnv,
   feedbackChannelEnv, feedbackFileEnv,
-  cacheReportDialogEnv, inverseHelpUsageChanceEnv :: EnvVarName
+  cacheReportDialogEnv, inverseHelpUsageChanceEnv,
+  logLevelEnv :: EnvVarName
 appTokenEnv = "SLACK_TZ_APP_TOKEN"
 botTokenEnv = "SLACK_TZ_BOT_TOKEN"
 maxRetriesEnv = "SLACK_TZ_MAX_RETRIES"
@@ -53,6 +55,7 @@ feedbackChannelEnv = "SLACK_TZ_FEEDBACK_CHANNEL"
 feedbackFileEnv = "SLACK_TZ_FEEDBACK_FILE"
 cacheReportDialogEnv = "SLACK_TZ_CACHE_REPORT_DIALOG"
 inverseHelpUsageChanceEnv = "SLACK_TZ_INVERSE_HELP_USAGE_CHANCE"
+logLevelEnv = "SLACK_TZ_LOG_LEVEL"
 
 -- | Overall config.
 data Config f = Config
@@ -75,6 +78,8 @@ data Config f = Config
   , cInverseHelpUsageChance   :: Int
     -- ^ 1/p, where p is chance to append help command usage
     -- to the ephemeral message.
+  , cLogLevel                 :: Severity
+    -- ^ Log level.
   } deriving stock (Generic)
 
 deriving stock instance Eq (Config 'CSInterm)

--- a/src/TzBot/Feedback/Save.hs
+++ b/src/TzBot/Feedback/Save.hs
@@ -19,7 +19,7 @@ import Data.Time.Zones.All (toTZName)
 import Text.Interpolation.Nyan (int, rmode')
 
 import TzBot.Logger (KatipContext, error_, logTM)
-import TzBot.Render (TranslationPairs, renderSlackBlocks)
+import TzBot.Render (TranslationPairs, asForOthersS, renderSlackBlocks)
 import TzBot.RunMonad
 import TzBot.Slack (sendMessage)
 import TzBot.Slack.API
@@ -53,22 +53,21 @@ saveFeedbackSlack entry channelId = sendMessage req
     req = do
       -- We always render the translation for other users (not author),
       -- so the author can see how his message is translated for others
-      let forSender = False
-          pmrChannel = channelId
+      let pmrChannel = channelId
           pmrText = "New user feedback"
           pmrBlocks = NE.nonEmpty $
             [ BHeader (Header "Message")
             , BSection (textSection (PlainText $ feMessageText entry) Nothing)
             , BDivider divider
             , BHeader (Header "Time translation")
-            ] <> renderSlackBlocks forSender (feTimeTranslation entry)
+            ] <> renderSlackBlocks asForOthersS (feTimeTranslation entry)
             <>
             [ BDivider divider
             , BHeader (Header "Details")
             , BSection $ fieldsSection Nothing Nothing $
               ("Message timestamp", show $ feMessageTimestamp entry) :|
-              [ ("Sender timezone", PlainText $ cs $ toTZName $ feSenderTimezone entry)
-              , ("User report", PlainText $ feUserReport entry)
+              [ ("Sender timezone", Mrkdwn $ cs $ toTZName $ feSenderTimezone entry)
+              , ("User report", Mrkdwn $ feUserReport entry)
               ]
             ]
       PostMessageReq {..}

--- a/src/TzBot/Feedback/Save.hs
+++ b/src/TzBot/Feedback/Save.hs
@@ -18,6 +18,7 @@ import Data.Time.TZInfo (TZLabel)
 import Data.Time.Zones.All (toTZName)
 import Text.Interpolation.Nyan (int, rmode')
 
+import TzBot.Logger (KatipContext, error_, logTM)
 import TzBot.Render (TranslationPairs, renderSlackBlocks)
 import TzBot.RunMonad
 import TzBot.Slack (sendMessage)
@@ -33,9 +34,9 @@ data FeedbackEntry = FeedbackEntry
   } deriving stock (Show, Generic)
     deriving ToJSON via RecordWrapper FeedbackEntry
 
-logFeedbackError :: BotException -> BotM ()
+logFeedbackError :: (KatipContext m) => BotException -> m ()
 logFeedbackError (displayException -> err) = do
-  log' [int||Error occured while saving user feedback: #{err}|]
+  $(logTM) `error_` [int||Error occured while saving user feedback: #{err}|]
 
 -- | Save user feedback to the Slack channel if configured
 --   and record to the file if configured.

--- a/src/TzBot/Logger.hs
+++ b/src/TzBot/Logger.hs
@@ -1,0 +1,77 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module TzBot.Logger
+  ( module TzBot.Logger
+  , module Katip
+  ) where
+
+import Universum
+
+import Data.Aeson (KeyValue((.=)), ToJSON(..), object)
+import Katip
+
+import TzBot.Slack.API (MessageId(..))
+
+logSugar :: Severity -> (Severity -> LogStr -> m ()) -> Text -> m ()
+logSugar sev logFunc = logFunc sev . logStr
+
+debug, info, warn, error_ :: (Severity -> LogStr -> m ()) -> Text -> m ()
+debug = logSugar DebugS
+info = logSugar InfoS
+warn = logSugar WarningS
+error_ = logSugar ErrorS
+
+infix 5 `debug`
+infix 5 `info`
+infix 5 `warn`
+infix 5 `error_`
+
+withLogger
+  :: Severity
+  -> ((Namespace, LogContexts, LogEnv) -> IO a)
+  -> IO a
+withLogger logLevel action = do
+  handleScribe <- mkHandleScribe ColorIfTerminal stdout (permitItem logLevel) V2
+  let namespace = "main"
+      initialContext = mempty
+      environment = "general"
+      mainNamespace = "TzBot"
+      scribeName = "stdout"
+      mkLogEnv =
+        initLogEnv mainNamespace environment >>=
+        registerScribe scribeName handleScribe defaultScribeSettings
+  bracket mkLogEnv closeScribes $ \logEnv ->
+    action (namespace, initialContext, logEnv)
+
+katipAddNamespaceText :: (KatipContext m) => Text -> m a -> m a
+katipAddNamespaceText txt = katipAddNamespace $ Namespace [txt]
+
+-- contexts
+type EventType = Text
+type EventId = Text
+data EventContext = EventContext EventType EventId
+
+instance ToJSON EventContext where
+  toJSON (EventContext t cId) =
+    object
+      [ "event_type" .= t
+      , "event_id" .= cId
+      ]
+
+instance ToObject EventContext
+
+instance LogItem EventContext where
+  payloadKeys _verb _a = AllKeys
+
+--
+newtype MessageContext = MessageContext MessageId
+
+instance ToJSON MessageContext where
+  toJSON (MessageContext msgId) = object ["message_id" .= msgId]
+
+instance ToObject MessageContext
+
+instance LogItem MessageContext where
+  payloadKeys _verb _a = AllKeys

--- a/src/TzBot/ProcessEvents/BlockAction.hs
+++ b/src/TzBot/ProcessEvents/BlockAction.hs
@@ -15,7 +15,7 @@ import Text.Interpolation.Nyan (int, rmode')
 import TzBot.Feedback.Dialog (lookupDialogEntry)
 import TzBot.Feedback.Dialog.Types
   (ReportDialogEntry(ReportDialogEntry, rpmMessageText, rpmMessageTimestamp, rpmSenderTimeZone, rpmTimeTranslation))
-import TzBot.RunMonad (log')
+import TzBot.Logger (info, katipAddNamespaceText, logTM, warn)
 import TzBot.Slack (BotM, updateModal)
 import TzBot.Slack.API (UpdateViewReq(UpdateViewReq))
 import TzBot.Slack.Events
@@ -25,11 +25,13 @@ import TzBot.Slack.Modal (mkReportModal)
 --   The input block should be added to collect the user feedback,
 --   using `mkReportModal` function.
 processReportButtonToggled :: ViewActionEvent Value -> BotM ()
-processReportButtonToggled val = do
+processReportButtonToggled val =
+  katipAddNamespaceText "report_button_toggled" $ do
+  $(logTM) `info` [int||Report button of view #{vId $ vaeView val} toggled|]
   let metadataEntryId = vPrivateMetadata $ vaeView val
   mbMetadata <- lookupDialogEntry metadataEntryId
   case mbMetadata of
-    Nothing -> log' [int||Dialog id not found: #{metadataEntryId}|]
+    Nothing -> $(logTM) `warn` [int||Dialog id not found: #{metadataEntryId}|]
     Just _metadata@ReportDialogEntry {..} -> updateModal $
       UpdateViewReq
         (mkReportModal rpmMessageText rpmTimeTranslation metadataEntryId)

--- a/src/TzBot/ProcessEvents/ChannelEvent.hs
+++ b/src/TzBot/ProcessEvents/ChannelEvent.hs
@@ -10,19 +10,18 @@ import Data.Set qualified as S
 import Text.Interpolation.Nyan (int, rmode')
 
 import TzBot.Cache qualified as Cache
+import TzBot.Logger (info, logTM)
 import TzBot.RunMonad
 import TzBot.Slack.Events (MemberJoinedChannelEvent(..), MemberLeftChannelEvent(..))
 
 processMemberJoinedChannel :: MemberJoinedChannelEvent -> BotM ()
 processMemberJoinedChannel MemberJoinedChannelEvent {..} = do
-  log' [int||member_joined_channel: \
-               the user #{mjceUser} joined the channel #{mjceChannel}|]
+  $(logTM) `info` [int||user #{mjceUser} joined channel #{mjceChannel}|]
   channelMembersCache <- asks bsConversationMembersCache
   Cache.update mjceChannel (S.insert mjceUser) channelMembersCache
 
 processMemberLeftChannel :: MemberLeftChannelEvent -> BotM ()
 processMemberLeftChannel MemberLeftChannelEvent {..} = do
-  log' [int||member_left_channel: \
-               the user #{mlceUser} left the channel #{mlceChannel}|]
+  $(logTM) `info` [int||user #{mlceUser} left channel #{mlceChannel}|]
   channelMembersCache <- asks bsConversationMembersCache
   Cache.update mlceChannel (S.delete mlceUser) channelMembersCache

--- a/src/TzBot/ProcessEvents/Command.hs
+++ b/src/TzBot/ProcessEvents/Command.hs
@@ -7,7 +7,9 @@ module TzBot.ProcessEvents.Command where
 import Universum
 
 import Slacker (SlashCommand(..), scChannelId)
+import Text.Interpolation.Nyan (int, rmode')
 
+import TzBot.Logger (info, logTM)
 import TzBot.RunMonad (BotM(..))
 import TzBot.Slack (sendEphemeralMessage)
 import TzBot.Slack.API (ChannelId(..), PostEphemeralReq(..), UserId(..))
@@ -15,11 +17,12 @@ import TzBot.Slack.Fixtures qualified as Fixtures
 
 processHelpCommand :: SlashCommand -> BotM ()
 processHelpCommand SlashCommand {..} = do
-  let postEphemeralReq = PostEphemeralReq
+  let postEphemeralReq@PostEphemeralReq {..} = PostEphemeralReq
         { perUser = UserId scUserId
         , perChannel = ChannelId scChannelId
         , perText = Fixtures.helpMessage
         , perThreadTs = Nothing
         , perBlocks = Nothing
         }
+  $(logTM) `info` [int||Sending help message to user #{perUser}|]
   sendEphemeralMessage postEphemeralReq

--- a/src/TzBot/ProcessEvents/Common.hs
+++ b/src/TzBot/ProcessEvents/Common.hs
@@ -20,9 +20,9 @@ import Text.Interpolation.Nyan (int, rmode')
 
 import TzBot.Feedback.Dialog (insertDialogEntry)
 import TzBot.Feedback.Dialog.Types
+import TzBot.Logger (logTM, warn)
 import TzBot.Parser (parseTimeRefs)
 import TzBot.Render (TranslationPairs, renderAllForOthersTP, renderTemplate)
-import TzBot.RunMonad (log')
 import TzBot.Slack (BotM, getUserCached, startModal)
 import TzBot.Slack.API
 import TzBot.Slack.API.MessageBlock
@@ -86,18 +86,18 @@ getTextPiecesFromMessage message = do
   let throwAwayTooShort = filter (\x -> T.compareLength x 2 == GT)
   throwAwayTooShort <$> case unUnknown $ msgBlocks message of
     Left unknownBlocksValue -> do
-      log' [int||warning: Failed to parse message blocks, \
+      $(logTM) `warn` [int||Failed to parse message blocks, \
                  trying to ignore code blocks manually|]
-      log' [int||warning: Unrecognized message blocks: \
+      $(logTM) `warn` [int||Unrecognized message blocks: \
                  #{encodePrettyToTextBuilder unknownBlocksValue}|]
       pure $ ignoreCodeBlocksManually $ mText message
     Right blocks -> do
       let (pieces, exErrs) = extractPieces blocks
       let (l1Errs, l2Errs) = splitExtractErrors exErrs
       when (not $ null l1Errs) $
-        log' [int||warning: Unknown level1 block types: #{listF $ map (show @Text) l1Errs}|]
+        $(logTM) `warn` [int||Unknown level1 block types: #{listF $ map (show @Text) l1Errs}|]
       when (not $ null l2Errs) $
-        log' [int||warning: Unknown level2 block types: #{listF $ map ubeType l2Errs}|]
+        $(logTM) `warn` [int||Unknown level2 block types: #{listF $ map ubeType l2Errs}|]
       pure pieces
 
 {- | Simple function that works in a very naive way, but it's just reserve

--- a/src/TzBot/ProcessEvents/Message.hs
+++ b/src/TzBot/ProcessEvents/Message.hs
@@ -6,24 +6,28 @@ module TzBot.ProcessEvents.Message
   ( processMessageEvent
   ) where
 
-import Universum
+import Universum hiding (try)
 
-import Control.Concurrent.Async.Lifted (forConcurrently_)
+import Control.Concurrent.Async.Lifted (forConcurrently)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
 import Data.Set qualified as S
+import Data.Text.Lazy.Builder (Builder)
 import System.Random (randomRIO)
+import Text.Interpolation.Nyan (int, rmode', rmode's)
 
 import TzBot.Config (Config(..))
+import TzBot.Logger
+  (KatipContext, MessageContext(MessageContext), debug, error_, info, katipAddContext,
+  katipAddNamespaceText, logTM)
 import TzBot.ProcessEvents.Common (getTimeReferencesFromMessage)
 import TzBot.Render
-import TzBot.RunMonad (log')
 import TzBot.Slack
 import TzBot.Slack.API
 import TzBot.Slack.Events
 import TzBot.Slack.Fixtures qualified as Fixtures
 import TzBot.TimeReference (TimeReference(trText), TimeReferenceText)
-import TzBot.Util (isDevEnvironment)
+import TzBot.Util (catchAllErrors, isDevEnvironment, withMaybe)
 
 -- Helper function for `filterNewReferencesAndMemorize`
 filterNewReferencesAndMemorizePure
@@ -60,13 +64,34 @@ filterNewReferencesAndMemorize messageId timeRefs = NE.nonEmpty <$> do
 -- We don't need to handle MDMessageBroadcast anyhow,
 -- because we were supposed to reply to the original message
 -- in the thread earlier.
-newMessageOrEditedMessage :: MessageEvent -> Bool
-newMessageOrEditedMessage evt = case meMessageDetails evt of
-  MDMessage           -> True
-  MDMessageEdited {}  -> True
-  MDMessageBroadcast  -> False
-  MDUserJoinedChannel -> False
-  MDUserLeftChannel   -> False
+-- channel_join and channel_leave messages are also ignored because
+-- we handle these events in another way.
+filterMessageTypeWithLog :: (KatipContext m) => MessageEvent -> m Bool
+filterMessageTypeWithLog evt = case meMessageDetails evt of
+  MDMessage          -> do
+    $(logTM) `info` [int||Handling new message|]
+    pure True
+  MDMessageEdited {} -> do
+    $(logTM) `info` [int||Message was edited|]
+    pure True
+  MDMessageBroadcast -> do
+    $(logTM) `info` [int||Incoming message is thread broadcast, ignoring|]
+    pure False
+  MDUserJoinedChannel -> do
+    $(logTM) `info` [int||Incoming message subtype=channel_join, ignoring|]
+    pure False
+  MDUserLeftChannel -> do
+    $(logTM) `info` [int||Incoming message subtype=channel_leave, ignoring|]
+    pure False
+
+withSenderNotBot :: MessageEvent -> BotM (Maybe User)
+withSenderNotBot evt = do
+  sender <- getUserCached $ mUser $ meMessage evt
+  if uIsBot sender
+    then do
+      $(logTM) `info` [int||Sender is bot, ignoring|]
+      pure Nothing
+    else pure $ Just sender
 
 -- | Process incoming Slack message events. Only "message" and "message_edited" are processed.
 --
@@ -80,19 +105,24 @@ newMessageOrEditedMessage evt = case meMessageDetails evt of
 -- "message_edited" event is processed similarly, but only most recently added time
 -- references are processed and sent via ephemerals.
 processMessageEvent :: MessageEvent -> BotM ()
-processMessageEvent evt = when (newMessageOrEditedMessage evt) $ do
+processMessageEvent evt =
+  katipAddNamespaceText "message" $
+  katipAddContext (MessageContext (mMessageId $ meMessage evt)) $
+  whenM (filterMessageTypeWithLog evt) $
+    whenJustM (withSenderNotBot evt) $ \sender -> do
   let msg = meMessage evt
 
   -- TODO: use some "transactions here"? Or just lookup the map multiple times.
   timeRefs <- getTimeReferencesFromMessage msg
   mbReferencesToCheck <-
     filterNewReferencesAndMemorize (mMessageId msg) timeRefs
-  whenJust mbReferencesToCheck $ \timeRefs-> do
+  withMaybe mbReferencesToCheck
+    ($(logTM) `info` "No time references for processing found")
+      \timeRefs -> do
     inverseChance <- asks $ cInverseHelpUsageChance . bsConfig
-    sender <- getUserCached $ mUser msg
 
     whetherToShowHelpCmd <- liftIO $ fmap (== 1) $ randomRIO (1, inverseChance)
-    when whetherToShowHelpCmd $ log' "appending help command usage"
+    when whetherToShowHelpCmd $ $(logTM) `debug` "appending help command usage"
 
     let now = meTs evt
         channelId = meChannel evt
@@ -122,25 +152,53 @@ processMessageEvent evt = when (newMessageOrEditedMessage evt) $ do
       -- it if it were sent to the common channel.
       Just CTDirectChannel -> do
         let ephemeralMessage = renderAllForOthersTP sender ephemeralTemplate
+        $(logTM) `info` [int||Received message from the DM, sending translation \
+                              to the author|]
         sendAction False ephemeralMessage (uId sender)
       _ -> do
         usersInChannelIds <- getChannelMembersCached channelId
 
-        whenJust (renderErrorsForSenderTP ephemeralTemplate) $ \errorsMsg ->
+        whenJust (renderErrorsForSenderTP ephemeralTemplate) $ \errorsMsg -> do
+          $(logTM) `info`
+            [int||Found invalid time references, \
+                      sending an ephemeral with them to the message sender|]
           sendAction True errorsMsg (uId sender)
 
         let notBotAndSameTimeZone u = not (uIsBot u) && uTz u /= uTz sender
             notSender userId = userId /= uId sender
+            setSize = S.size usersInChannelIds
 
-        forConcurrently_ usersInChannelIds $ \userInChannelId ->
+        $(logTM) `info` [int||#{setSize} users in the channel #{channelId}, sending ephemerals|]
+        eithRes <- forConcurrently (toList usersInChannelIds) $ \userInChannelId -> catchAllErrors $
           if isDevEnvironment
           then do
             userInChannel <- getUserCached userInChannelId
             let ephemeralMessage = renderAllForOthersTP userInChannel ephemeralTemplate
             sendAction False ephemeralMessage (uId userInChannel)
-          else
-            when (notSender userInChannelId) $ do
+            pure True
+          else do
+            let whenT :: (Monad m) => Bool -> m Bool -> m Bool
+                whenT cond_ action_ = if cond_ then action_ else pure False
+            whenT (notSender userInChannelId) $ do
               userInChannel <- getUserCached userInChannelId
-              when (notBotAndSameTimeZone userInChannel) $ do
+              whenT (notBotAndSameTimeZone userInChannel) $ do
                 let ephemeralMessage = renderAllForOthersTP userInChannel ephemeralTemplate
                 sendAction False ephemeralMessage (uId userInChannel)
+                pure True
+
+        let failedMsg = "Ephemeral sending failed" :: Builder
+            logAll :: Either SomeException BotException -> BotM ()
+            logAll (Left se) = $(logTM) `error_` [int||#{failedMsg}, unknown error occured: #s{se}|]
+            logAll (Right ke) = $(logTM) `error_` [int||#{failedMsg}, #{displayException ke}|]
+
+            processResult
+              :: (Int, Int)
+              -> Either (Either SomeException BotException) Bool
+              -> BotM (Int, Int)
+            processResult (oks_, errs_) eithRes_ = case eithRes_ of
+              Left err_ -> logAll err_ >> pure (oks_, errs_ + 1)
+              Right ok_ -> let oks_' = if ok_ then oks_ + 1 else oks_ in pure (oks_', errs_)
+        (oks, errs) <- foldM processResult (0, 0) eithRes
+        $(logTM) `info` [int||#{oks} ephemeral sent successfully|]
+        $(logTM) `info` [int||#{errs} ephemerals failed|]
+        pure ()

--- a/src/TzBot/Render.hs
+++ b/src/TzBot/Render.hs
@@ -9,12 +9,10 @@ module TzBot.Render
   , Template
 
     -- * Render generic
-  , renderAllForOthersTP
-  , renderErrorsForSenderTP
+  , renderAllTP
 
     -- * Render text
-  , renderErrorsForSender
-  , renderAllForOthers
+  , renderAll
   , joinTranslationPairs
 
     -- * Render Slack
@@ -22,13 +20,23 @@ module TzBot.Render
 
     -- * General template
   , renderTemplate
+
+    -- * Flags
+  , SenderFlag (..)
+  , asForSenderS
+  , asForOthersS
+
+  , ModalFlag (..)
+  , asForModalM
+  , asForMessageM
   ) where
 
 import Universum
 
 import Data.Aeson (ToJSON)
 import Data.List.NonEmpty qualified as NE
-import Data.Text.Lazy qualified as T
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Builder (Builder, fromText, singleton, toLazyText)
 import Data.Time.Compat
   (LocalTime(localDay), UTCTime, defaultTimeLocale, formatTime, pattern YearMonthDay)
@@ -38,7 +46,7 @@ import Data.Time.Zones.All (TZLabel)
 import Text.Interpolation.Nyan (int, rmode')
 
 import TzBot.Instances ()
-import TzBot.Slack.API (Mrkdwn(Mrkdwn), PlainText(..), User(uTz))
+import TzBot.Slack.API (Mrkdwn(Mrkdwn), PlainText(..), User(..))
 import TzBot.Slack.API.Block
 import TzBot.TimeReference
 import TzBot.Util
@@ -48,7 +56,7 @@ import TzBot.Util
 -- We use `Left` to keep translation errors (invalid/ambiguous time,
 -- invalid offset abbreviation) and they are common for all users,
 -- and valid translations (`Right`) depend on the receiver timezone.
-type EitherTemplateUnit = Either TranslationPair (User -> TranslationPair)
+type EitherTemplateUnit = Either TranslationPair (User -> Maybe TranslationPair)
 
 data TranslationPair = TranslationPair
   { tuTimeRef :: Text
@@ -66,21 +74,29 @@ type TranslationPairs = NE.NonEmpty TranslationPair
 
 newtype Template = Template { unTemplate :: NE.NonEmpty EitherTemplateUnit }
 
-chooseNote :: Bool -> TranslationPair -> Maybe Text
-chooseNote sender = if sender then tuNoteForSender else tuNoteForOthers
+---------------------------------------
+-- Notes
+---------------------------------------
+-- | Used for choosing between two notes
+newtype SenderFlag = SenderFlag { unSenderFlag :: Bool }
 
-concatTranslationPair :: Bool -> TranslationPair -> Builder
+asForSenderS, asForOthersS :: SenderFlag
+asForSenderS = SenderFlag True
+asForOthersS = SenderFlag False
+
+chooseNote :: SenderFlag -> TranslationPair -> Maybe Text
+chooseNote (SenderFlag sender) = if sender then tuNoteForSender else tuNoteForOthers
+
+--
+concatTranslationPair :: SenderFlag -> TranslationPair -> Builder
 concatTranslationPair sender t@TranslationPair {..} = do
   let rightNote = chooseNote sender t
   let note = maybe "" (("\n" <>) . fromText) rightNote
   [int||#{tuTimeRef}:  #{tuTranslation}#{note}|]
 
--- Render generic
-renderErrorsForSenderTP :: Template -> Maybe TranslationPairs
-renderErrorsForSenderTP (Template lst) = NE.nonEmpty $ lefts $ NE.toList lst
-
-renderAllForOthersTP :: User -> Template -> TranslationPairs
-renderAllForOthersTP user = NE.map (either id ($ user)) . unTemplate
+renderAllTP :: User -> Template -> Maybe TranslationPairs
+renderAllTP user =
+  nonEmpty . mapMaybe (either Just ($ user)) . NE.toList . unTemplate
 
 -- | We show this message because we may have not found
 -- any time references while actually there were.
@@ -88,23 +104,17 @@ noRefsFoundMsg :: Text
 noRefsFoundMsg = "No time references found."
 
 -- Render text
-renderErrorsForSender :: Template -> Maybe Text
-renderErrorsForSender template = do
-  let sender = True
-  joinTranslationPairs sender <$> renderErrorsForSenderTP template
+renderAll :: User -> Template -> Maybe Text
+renderAll user =
+  fmap (joinTranslationPairs asForSenderS) . renderAllTP user
 
-renderAllForOthers :: User -> Template -> Text
-renderAllForOthers user = do
-  let sender = False
-  joinTranslationPairs sender . renderAllForOthersTP user
-
-joinTranslationPairs :: Bool -> TranslationPairs -> Text
+joinTranslationPairs :: SenderFlag -> TranslationPairs -> Text
 joinTranslationPairs sender =
-  T.toStrict . toLazyText . fold . NE.toList
+  TL.toStrict . toLazyText . fold . NE.toList
     . NE.map ((<> singleton '\n') . concatTranslationPair sender)
 
 -- Render Slack block
-renderSlackBlocks :: Bool -> Maybe TranslationPairs -> [Block]
+renderSlackBlocks :: SenderFlag -> Maybe TranslationPairs -> [Block]
 renderSlackBlocks forSender =
   maybe [noRefsFoundSection]
     (intercalate [BDivider divider] . NE.toList . NE.map mkTranslationBlocks)
@@ -112,67 +122,106 @@ renderSlackBlocks forSender =
     noRefsFoundSection = BSection $ textSection (PlainText noRefsFoundMsg) Nothing
     mkTranslationBlocks :: TranslationPair -> [Block]
     mkTranslationBlocks timeRef = do
-      let t = (PlainText $ tuTimeRef timeRef, PlainText $ tuTranslation timeRef)
+      let t = (Mrkdwn $ tuTimeRef timeRef, Mrkdwn $ tuTranslation timeRef)
           mbNote = chooseNote forSender timeRef
           translationBlock = BSection $ fieldsSection Nothing Nothing $ NE.singleton t
           mkNoteBlock note = BSection $ markdownSection (Mrkdwn note) Nothing
       withMaybe mbNote [translationBlock] $ \note -> [translationBlock, mkNoteBlock note]
 
-renderTemplate :: UTCTime -> User -> NE.NonEmpty TimeReference -> Template
-renderTemplate now sender timeRefs =
-  Template $ NE.map (renderEphemeralMessageTranslationPair now sender)
+renderTemplate :: ModalFlag -> UTCTime -> User -> NE.NonEmpty TimeReference -> Template
+renderTemplate asForModal now sender timeRefs =
+  Template $ NE.map (renderEphemeralMessageTranslationPair asForModal now sender)
     $ attach (timeReferenceToUTC (uTz sender) now) timeRefs
+
+--
+newtype ModalFlag = ModalFlag { unModalFlag :: Bool }
+
+asForModalM, asForMessageM :: ModalFlag
+asForModalM = ModalFlag True
+asForMessageM = ModalFlag False
+
+--
+renderTranslationOnSuccess
+  :: ModalFlag
+  -> UTCTime
+  -> User
+  -> TimeReference
+  -> TimeRefSuccess
+  -> User
+  -> Maybe TranslationPair
+renderTranslationOnSuccess
+  (ModalFlag forModal) now sender timeRef (TimeRefSuccess {..}) user
+    = do
+  let userTzLabel = uTz user
+      isSender = ((/=) `on` uId) sender user
+      shouldShowThisTranslation = isSender || forModal
+      renderedUserTime =
+        T.pack $ renderUserTime trsIsDateInferred userTzLabel now trsUtcResult
+      mbRenderedTranslation = case trsEithTzOffset of
+        Right _ -> Just renderedUserTime
+        Left refTzLabel ->
+          if refTzLabel == userTzLabel
+          then guard shouldShowThisTranslation >> Just "*your timezone is the same*"
+          else Just renderedUserTime
+
+  (<$> mbRenderedTranslation) $ \rt -> TranslationPair
+      (renderOriginalTimeRef sender timeRef)
+      rt
+      Nothing
+      Nothing
+
+renderOriginalTimeRef :: User -> TimeReference -> Text
+renderOriginalTimeRef sender timeRef = do
+  let mbSenderTimeZone :: Maybe Builder
+      mbSenderTimeZone = case trLocationRef timeRef of
+        Just _ -> Nothing
+        Nothing -> Just [int|| in #{uTz sender}|]
+  [int||"#{trText timeRef}"#{mbSenderTimeZone}:|]
 
 -- Under `Left` we collect errors, that should be shown to all users (including sender),
 -- and under `Right` we collect valid time references that should be rendered differently
 -- for each user.
 renderEphemeralMessageTranslationPair
-  :: UTCTime
+  :: ModalFlag
+  -> UTCTime
   -> User
   -> (TimeReference, TimeReferenceToUTCResult)
   -> EitherTemplateUnit
-renderEphemeralMessageTranslationPair now sender (timeRef, result) = case result of
-  TRTUSuccess utcTime _offsetInfo -> do
-    let mbSenderTimeZone =
-          guard (isNothing $ trLocationRef timeRef)
-            $> (uTz sender) :: Maybe TZLabel
-        mbSenderTimeZoneAux = mbSenderTimeZone $> " in " :: Maybe Text
-    Right $ \user -> do
-      let userTzLabel = uTz user
-          renderedUserTime = renderUserTime userTzLabel now utcTime
-      TranslationPair
-        [int||"#{trText timeRef}"#{mbSenderTimeZoneAux}#{mbSenderTimeZone}|]
-        [int||#{renderedUserTime} in #{userTzLabel}|]
-        Nothing
-        Nothing
-  TRTUAmbiguous implicitSenderTimezone tzLabel -> do
-    let shownTZ = shownTimezone implicitSenderTimezone tzLabel
+renderEphemeralMessageTranslationPair asForModal now sender (timeRef, result)
+    = case result of
+  TRTUSuccess trSucc ->
+    Right $ renderTranslationOnSuccess asForModal now sender timeRef trSucc
+  TRTUAmbiguous timeShiftErrorInfo -> do
+    let shownTZ = shownTimezone timeShiftErrorInfo
     Left $ TranslationPair
-      { tuTimeRef = trText timeRef
-      , tuTranslation = "ambiguous because of the time shift"
-      , tuNoteForSender =
-        Just [int||_There is a timeshift in #{shownTZ True} around the specified \
-             time and this particular timestamp can be possible with \
-             different offsets, please define the offset explicitly._|]
-      , tuNoteForOthers =
-        Just [int||_There is a time zone shift in #{shownTZ False} around that \
-             time, and this particular timestamp can be possible with \
-             different offsets._|]
+      { tuTimeRef = renderOriginalTimeRef sender timeRef
+      , tuTranslation = "*ambiguous because of the time shift*"
+      , tuNoteForSender = Just
+          [int|n|_There is a timeshift in #{shownTZ True} around the specified
+                  time and this particular timestamp can be possible with
+                  different offsets, please define the offset explicitly._
+          |]
+      , tuNoteForOthers = Just
+          [int|n|_There is a time zone shift in #{shownTZ False} around that
+                  time, and this particular timestamp can be possible with
+                  different offsets._
+          |]
       }
-  TRTUInvalid implicitSenderTimezone tzLabel -> do
-    let shownTZ = shownTimezone implicitSenderTimezone tzLabel
+  TRTUInvalid timeShiftErrorInfo -> do
+    let shownTZ = shownTimezone timeShiftErrorInfo
     Left $ TranslationPair
-      { tuTimeRef = trText timeRef
-      , tuTranslation = "invalid because of the time shift"
-      , tuNoteForSender =
-        Just [int||_There is a timeshift in #{shownTZ True} around the specified \
-             time and this particular timestamp does not exist, \
-             please define the offset explicitly._|]
-      , tuNoteForOthers =
-        Just [int||_There is a time zone shift in #{shownTZ False} around that \
-             time, and this particular timestamp does not exist._|]
+      { tuTimeRef = renderOriginalTimeRef sender timeRef
+      , tuTranslation = "*invalid because of the time shift*"
+      , tuNoteForSender = Just
+          [int|n|_There is a timeshift in #{shownTZ True} around the specified
+                  time and this particular timestamp does not exist,
+                  please define the offset explicitly._
+          |]
+      , tuNoteForOthers = Just
+          [int|n|_There is a time zone shift in #{shownTZ False} around that
+                  time, and this particular timestamp does not exist._
+          |]
       }
-
   TRTUInvalidTimeZoneAbbrev abbrev ->
     Left $ TranslationPair
       (trText timeRef)
@@ -181,24 +230,27 @@ renderEphemeralMessageTranslationPair now sender (timeRef, result) = case result
               -- what the sender defined and that we know about
       Nothing
   where
-    shownTimezone :: Bool -> TZLabel -> Bool -> Builder
-    shownTimezone implicitSenderTimezone tzLabel forSender
-      | implicitSenderTimezone =
+    shownTimezone :: TimeShiftErrorInfo -> Bool -> Builder
+    shownTimezone (TimeShiftErrorInfo {..}) forSender
+      | tseiIsImplicitSenderTimezone =
           if forSender
-          then [int||your timezone (#{tzLabel})|]
-          else [int||the sender's timezone (#{tzLabel})|]
-      | otherwise = [int||#{tzLabel}|]
+          then [int||your timezone (#{tseiRefTimeZone})|]
+          else [int||the sender's timezone (#{tseiRefTimeZone})|]
+      | otherwise = [int||#{tseiRefTimeZone}|]
 
-renderUserTime :: TZLabel -> UTCTime -> UTCTime -> String
-renderUserTime tzLabel now refTime = do
+renderUserTime :: Bool -> TZLabel -> UTCTime -> UTCTime -> String
+renderUserTime isDateInferred tzLabel now refTime = do
   let tzInfo = TZI.fromLabel tzLabel
       currentUserLocalTime = TZT.tzTimeLocalTime $ TZT.fromUTC tzInfo now
       refUserLocalTime = TZT.tzTimeLocalTime $ TZT.fromUTC tzInfo refTime
       sameYear = theYearIsTheSame currentUserLocalTime refUserLocalTime
-      yearFormat = if sameYear then "" else ", %Y"
-      -- example:
-      -- 18:23, Monday, December 26, 2016
-      format = "%H:%M, %A, %B %d" <> yearFormat
+      yearFormat = if sameYear then "" else ", %Y" :: Builder
+      dateFormat = [int||%A, %B %d|] :: Builder
+      timeFormat = [int||%H:%M in #{tzLabel}|] :: Builder
+      format = if not isDateInferred
+               then [int||*#{timeFormat}, #{dateFormat}#{yearFormat}*|] :: String
+               else [int||*#{timeFormat}* (possibly, #{dateFormat}#{yearFormat})|]
+
   formatTime defaultTimeLocale format refUserLocalTime
 
 theYearIsTheSame :: LocalTime -> LocalTime -> Bool

--- a/src/TzBot/Slack.hs
+++ b/src/TzBot/Slack.hs
@@ -23,7 +23,6 @@ module TzBot.Slack
 
 import Universum hiding (toString)
 
-import Control.Concurrent (threadDelay)
 import Control.Monad.Except (throwError)
 import Data.Aeson (Value)
 import Data.ByteString.UTF8 (toString)
@@ -39,11 +38,14 @@ import Servant.Client
 import Servant.Client.Core
   (ClientError(FailureResponse), ResponseF(responseHeaders, responseStatusCode))
 import Text.Interpolation.Nyan (int, rmode', rmode's)
+import Time.Units (sec, threadDelay)
 
 import TzBot.Cache qualified as Cache
-import TzBot.Config (AppLevelToken(..), BotToken(..), Config(..))
+import TzBot.Config
+import TzBot.Logger
 import TzBot.RunMonad
-  (BotException(..), BotM(..), BotState(..), ErrorDescription, log', runBotM, runOrThrowBotM)
+  (BotException(..), BotM(..), BotState(..), ErrorDescription, runBotM, runKatipWithBotState,
+  runOrThrowBotM)
 import TzBot.Slack.API
   (ChannelId, Cursor, Limit(..), Message(..), MessageId(..), OpenViewReq(..), PostEphemeralReq(..),
   PostMessageReq(..), SlackContents(..), SlackResponse(..), ThreadId, UpdateViewReq(..), User,
@@ -58,8 +60,9 @@ getUser userId = do
 -- | Get a user's info using cache.
 getUserCached :: UserId -> BotM User
 getUserCached userId =
-  asks bsUserInfoCache
-    >>= Cache.fetchWithCacheRandomized userId getUser
+  katipAddNamespaceText "getUser" $ do
+  cache <- asks bsUserInfoCache
+  Cache.fetchWithCacheRandomized userId getUser cache
 
 -- | Get a list of a channel's members.
 getChannelMembers :: ChannelId -> BotM (S.Set UserId)
@@ -72,8 +75,9 @@ getChannelMembers channelId = do
 
 getChannelMembersCached :: ChannelId -> BotM (S.Set UserId)
 getChannelMembersCached channelId =
-  asks bsConversationMembersCache
-    >>= Cache.fetchWithCacheRandomized channelId getChannelMembers
+  katipAddNamespaceText "getChannelMembers" $ do
+  cache <- asks bsConversationMembersCache
+  Cache.fetchWithCacheRandomized channelId getChannelMembers cache
 
 -- | Post an "ephemeral message", a message only visible to the given user.
 sendEphemeralMessage :: PostEphemeralReq -> BotM ()
@@ -160,9 +164,9 @@ getBotToken = do
 handleSlackError :: Text -> SlackResponse a -> BotM a
 handleSlackError endpoint = \case
   SRSuccess a -> pure a
-  SRError err metadata -> do
-    log' [int||#{endpoint} error: #{err}; metadata: #s{metadata}|]
-    throwError $ EndpointFailed endpoint err
+  SRError err_ metadata -> do
+    $(logTM) `error_` [int||#{endpoint} error: #{err_}; metadata: #s{metadata}|]
+    throwError $ EndpointFailed endpoint err_
 
 handleSlackErrorSingle :: Text -> SlackResponse $ SlackContents key a -> BotM a
 handleSlackErrorSingle endpoint = fmap scContents . handleSlackError endpoint
@@ -232,48 +236,59 @@ usersInfo
     baseUrl = BaseUrl Https "slack.com" 443 "api"
 
     naturalTransformation :: ClientM a -> BotM a
-    naturalTransformation act = BotM do
+    naturalTransformation act = do
+      botState <- ask
       manager <- asks bsManager
       config <- asks bsConfig
       let clientEnv = mkClientEnv manager baseUrl
-      liftIO (evalStateT (handleTooManyRequests (runClientM act clientEnv)) (cMaxRetries config)) >>= \case
+      liftIO (evalStateT
+        (runKatipWithBotState botState $
+          handleTooManyRequests (runClientM act clientEnv)) (cMaxRetries config)) >>= \case
         Right a -> pure a
-        Left clientError -> throwError $ ServantError clientError
+        Left clientError -> do
+          $(logTM) `error_` [int||Client call failed: ${show @Text clientError}|]
+          throwError $ ServantError clientError
 
 -- | Handles slack API response with status code 429 @Too many requests@.
 -- If action result is success, then return result. If action result is error
 -- with response status code 429 and attempts are not exceeded then try the action again.
-handleTooManyRequests :: IO (Either ClientError a) -> StateT Int IO (Either ClientError a)
+handleTooManyRequests
+  :: forall a.
+     IO (Either ClientError a)
+  -> KatipContextT (StateT Int IO) (Either ClientError a)
 handleTooManyRequests botAction = do
   result <- liftIO botAction
   case result of
     Right _ -> return result
     Left err -> handle err
   where
+    handle :: ClientError -> KatipContextT (StateT Int IO) (Either ClientError a)
     handle err = case err of
         FailureResponse _ response ->
           if ((statusCode . responseStatusCode $ response) == 429)
-          -- TODO: Add logging when handling 429 response status code
             then do
+              $(logTM) `error_` "Client call returned 429 status code"
               attempts <- get
               if attempts > 0
                 then do
-                  let retryAfterHeader =
-                        Seq.filter ((== "Retry-After") . fst) (responseHeaders response)
-                  if Seq.null retryAfterHeader
-                    then return $ Left err -- if there is no Retri-After header don't handle 429 response
-                    else do
-                      let retryAfter =
-                            fmap (ceiling . (* 10^(6 :: Int)))
-                                (readMaybe $
-                                  toString . snd $
-                                  Seq.index retryAfterHeader 0 :: Maybe Double)
-                      maybe (pure $ Left err) (waitAndTryAgain botAction) retryAfter
-                else return $ Left err -- if number of attempts are exceeded don't try anymore
+                  let mbRetryAfterHeader =
+                        fmap snd $ Seq.lookup 0
+                          $ Seq.filter ((== "Retry-After") . fst) (responseHeaders response)
+                      parseRetryAfterSec :: ByteString -> Maybe Double
+                      parseRetryAfterSec bs = readMaybe @Double (toString bs)
+                  case mbRetryAfterHeader >>= parseRetryAfterSec of
+                    Nothing -> do
+                      $(logTM) `error_` "Header \"Retry-After\" not found or invalid, cannot retry"
+                      return $ Left err -- if there is no Retry-After header don't handle 429 response
+                    Just retryAfter -> do
+                      let delay = sec $ realToFrac retryAfter
+                      $(logTM) `error_`
+                        [int||Retrying again in #{retryAfter}, #{attempts-1} attempts remaining|]
+                      threadDelay delay
+                      modify (subtract 1)
+                      handleTooManyRequests botAction
+                else do
+                  $(logTM) `error_` "Attempts amount exceeded, stopping"
+                  return $ Left err -- if number of attempts are exceeded don't try anymore
             else return $ Left err -- if response code is other than 429 don't do anything
         _ -> return $ Left err -- if servant response is other than FailureResponse don't do anything
-    waitAndTryAgain :: IO (Either ClientError a) -> Int -> StateT Int IO (Either ClientError a)
-    waitAndTryAgain action delay = do
-      liftIO . threadDelay $ delay
-      modify (subtract 1)
-      handleTooManyRequests action

--- a/src/TzBot/Slack/API.hs
+++ b/src/TzBot/Slack/API.hs
@@ -167,7 +167,7 @@ instance (KnownSymbol key, FromJSON a) => FromJSON (SlackContents key a) where
 
 newtype UserId = UserId { unUserId :: Text }
   deriving stock (Eq, Ord, Show)
-  deriving newtype (ToHttpApiData, FromJSON, ToJSON, Hashable, Buildable)
+  deriving newtype (ToHttpApiData, FromJSON, ToJSON, Hashable, Buildable, IsString)
 
 newtype ChannelId = ChannelId { unChannelId :: Text }
   deriving stock (Eq, Show)

--- a/src/TzBot/Slack/API.hs
+++ b/src/TzBot/Slack/API.hs
@@ -208,7 +208,7 @@ newtype TriggerId = TriggerId { unTriggerId :: Text }
 
 newtype ViewId = ViewId { unViewId :: Text }
   deriving stock (Eq, Show, Ord)
-  deriving newtype (IsString, ToJSON, FromJSON)
+  deriving newtype (IsString, ToJSON, FromJSON, Buildable)
 
 -- See https://api.slack.com/events/message
 data Message = Message

--- a/src/TzBot/Slack/API/Block.hs
+++ b/src/TzBot/Slack/API/Block.hs
@@ -53,7 +53,7 @@ data Block
 data Section = Section
   { sText :: Maybe TextObject
   , sAccessory :: Maybe Button
-  , sFields :: Maybe (NE.NonEmpty PlainText)
+  , sFields :: Maybe (NE.NonEmpty Mrkdwn)
   } deriving stock (Eq, Show, Generic)
     deriving ToJSON via TypedWrapper Section
 
@@ -63,7 +63,7 @@ textSection text mbButton = Section (Just $ TOPlainText text) mbButton Nothing
 markdownSection :: Mrkdwn -> Maybe Button -> Section
 markdownSection markdown mbButton = Section (Just $ TOMarkdownText markdown) mbButton Nothing
 
-fieldsSection :: Maybe TextObject -> Maybe Button -> NE.NonEmpty (PlainText, PlainText) -> Section
+fieldsSection :: Maybe TextObject -> Maybe Button -> NE.NonEmpty (Mrkdwn, Mrkdwn) -> Section
 fieldsSection mbText mbButton fields =
   Section mbText mbButton $ Just $ neConcatMap (\(x, y) -> x :| [y]) fields
 

--- a/src/TzBot/Slack/Modal.hs
+++ b/src/TzBot/Slack/Modal.hs
@@ -10,7 +10,7 @@ import Data.List (singleton)
 
 import TzBot.Feedback.Dialog.Types
 import TzBot.Instances ()
-import TzBot.Render (TranslationPairs, renderSlackBlocks)
+import TzBot.Render (TranslationPairs, asForOthersS, renderSlackBlocks)
 import TzBot.Slack.API
 import TzBot.Slack.Fixtures qualified as Fixtures
 
@@ -64,13 +64,12 @@ mkBlocks :: Text -> Maybe TranslationPairs -> Block -> [Block]
 mkBlocks shownMessageText translatedMessage block =
   -- We always render the translation for other users (not author),
   -- so the author can see how his message is translated for others
-  let forSender = False in
   [ BHeader Header { hText = PlainText "Message text" }
   , BSection $ textSection (PlainText shownMessageText) Nothing
   , BDivider divider
   , BHeader Header { hText = PlainText "Time references" }
   ]
-  <> renderSlackBlocks forSender translatedMessage
+  <> renderSlackBlocks asForOthersS translatedMessage
   <> [ BDivider divider
   , block
   ]

--- a/src/TzBot/Util.hs
+++ b/src/TzBot/Util.hs
@@ -4,12 +4,16 @@
 
 module TzBot.Util where
 
-import Universum hiding (last)
+import Universum hiding (last, try)
 
+import Control.Exception.Lifted
+import Control.Lens (LensRules, lensField, lensRules, mappingNamer)
+import Control.Monad.Except (MonadError(catchError))
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Aeson
 import Data.Aeson qualified as AeKey
 import Data.Aeson qualified as Aeson
-import Data.Aeson.Casing (aesonPrefix, camelCase)
+import Data.Aeson.Casing
 import Data.Aeson.Key qualified as AeKey
 import Data.Aeson.Types (Parser, parseMaybe)
 import Data.Char (isLower)
@@ -156,3 +160,22 @@ instance (FromJSON a) => FromJSON (WithUnknown a) where
 
 instance (ToJSON a) => ToJSON (WithUnknown a) where
   toJSON (WithUnknown eith) = either (String . show) toJSON eith
+
+postfixFields :: LensRules
+postfixFields = lensRules & lensField .~ mappingNamer (\n -> [n ++ "L"])
+
+----
+-- not present in mtl-2.2.2
+tryError :: MonadError e m => m a -> m (Either e a)
+tryError action = (Right <$> action) `catchError` (pure . Left)
+
+catchAllErrors
+  :: (MonadError e m, MonadBaseControl IO m)
+  => m a
+  -> m (Either (Either SomeException e) a)
+catchAllErrors action = fmap reorder $ try $ tryError action
+  where
+  reorder :: Either e1 (Either e2 a) -> Either (Either e1 e2) a
+  reorder (Left e) = Left (Left e)
+  reorder (Right (Left e)) = Left (Right e)
+  reorder (Right (Right r)) = Right r

--- a/test/Test/TzBot/ConfigSpec.hs
+++ b/test/Test/TzBot/ConfigSpec.hs
@@ -47,6 +47,7 @@ configLoadingSpec =
             , (feedbackFileEnv, "feedback.log")
             , (cacheReportDialogEnv, "3m")
             , (inverseHelpUsageChanceEnv, "15")
+            , (logLevelEnv, "Info")
             ]
       eithConfig <- readConfigWithEnv env (Just "config/nonexistent.yaml")
       eithConfig `shouldSatisfy` isRight

--- a/test/Test/TzBot/RenderSpec.hs
+++ b/test/Test/TzBot/RenderSpec.hs
@@ -1,0 +1,170 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Test.TzBot.RenderSpec
+  ( test_renderSpec
+  ) where
+
+import Universum
+
+import Data.List (singleton)
+import Data.List.NonEmpty qualified as NE
+import Data.Time (UTCTime)
+import Data.Time.TZInfo (TZLabel(..))
+import Data.Time.TZTime (toUTC)
+import Data.Time.TZTime.QQ (tz)
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+import Test.Tasty.Runners (TestTree(..))
+import Text.Interpolation.Nyan
+import TzBot.Parser (parseTimeRefs)
+import TzBot.Render
+import TzBot.Slack.API (Block(..), Mrkdwn(..), User(..), fieldsSection, markdownSection)
+
+-- Sunday
+arbitraryTime1 :: UTCTime
+arbitraryTime1 = toUTC [tz|2023-01-30 00:30:00 [Europe/Moscow]|]
+
+arbitraryTime2 :: UTCTime
+arbitraryTime2 = toUTC [tz|2023-01-30 01:30:00 [Europe/Moscow]|]
+
+havanaTime1 :: UTCTime
+havanaTime1 = toUTC [tz|2023-03-11 01:30:00 [America/Havana]|]
+
+havanaTime2 :: UTCTime
+havanaTime2 = toUTC [tz|2022-11-05 01:30:00 [America/Havana]|]
+
+userMoscow :: User
+userMoscow = User {uId="msk1", uIsBot=False, uTz=Europe__Moscow}
+
+userHavana :: User
+userHavana = User {uId="hav", uIsBot=False, uTz=America__Havana}
+
+test_renderSpec :: TestTree
+test_renderSpec = TestGroup "Render" $
+  [ testCase "Implicit sender's timezone" $ mkTestCase arbitraryTime1 "10am" userMoscow userHavana
+
+      []
+      (mkBlocks "\"10am\" in Europe/Moscow:" "*02:00 in America/Havana* (possibly, Monday, January 30)")
+
+  , testCase "Inferred today" $ mkTestCase arbitraryTime1 "10am in Europe/Helsinki" userMoscow userHavana
+
+      (mkBlocks "\"10am in Europe/Helsinki\":" "*11:00 in Europe/Moscow* (possibly, Monday, January 30)")
+      (mkBlocks "\"10am in Europe/Helsinki\":" "*03:00 in America/Havana* (possibly, Monday, January 30)")
+
+  , testCase "Same timezone" $ mkTestCase arbitraryTime1 "10am in America/Havana" userMoscow userHavana
+
+      (mkBlocks "\"10am in America/Havana\":" "*18:00 in Europe/Moscow* (possibly, Monday, January 30)")
+      (mkBlocks "\"10am in America/Havana\":" "*your timezone is the same*")
+
+  , testCase "Close day of week" $ mkTestCase arbitraryTime1 "10am in Europe/Helsinki tuesday" userMoscow userHavana
+
+      (mkBlocks "\"10am in Europe/Helsinki tuesday\":" "*11:00 in Europe/Moscow, Tuesday, January 31*")
+      (mkBlocks "\"10am in Europe/Helsinki tuesday\":" "*03:00 in America/Havana, Tuesday, January 31*")
+
+  , testCase "Far day of week" $ mkTestCase arbitraryTime1 "10am in Europe/Helsinki thursday" userMoscow userHavana
+
+      (mkBlocks "\"10am in Europe/Helsinki thursday\":" "*11:00 in Europe/Moscow* (possibly, Thursday, February 02)")
+      (mkBlocks "\"10am in Europe/Helsinki thursday\":" "*03:00 in America/Havana* (possibly, Thursday, February 02)")
+
+  , testCase "Relative ref, unsure" $ mkTestCase arbitraryTime1 "10am in Europe/Helsinki tomorrow" userMoscow userHavana
+      -- not sure because it's already new day in Moscow
+      (mkBlocks "\"10am in Europe/Helsinki tomorrow\":" "*11:00 in Europe/Moscow* (possibly, Monday, January 30)")
+      (mkBlocks "\"10am in Europe/Helsinki tomorrow\":" "*03:00 in America/Havana* (possibly, Monday, January 30)")
+
+  , testCase "Relative ref, sure" $ mkTestCase arbitraryTime2 "10am in Europe/Helsinki tomorrow" userMoscow userHavana
+
+      (mkBlocks "\"10am in Europe/Helsinki tomorrow\":" "*11:00 in Europe/Moscow, Tuesday, January 31*")
+      (mkBlocks "\"10am in Europe/Helsinki tomorrow\":" "*03:00 in America/Havana, Tuesday, January 31*")
+
+  , testCase "Only day of month" $ mkTestCase arbitraryTime2 "10am in Europe/Helsinki on 3rd" userMoscow userHavana
+      -- not sure
+      (mkBlocks "\"10am in Europe/Helsinki on 3rd\":" "*11:00 in Europe/Moscow* (possibly, Friday, February 03)")
+      (mkBlocks "\"10am in Europe/Helsinki on 3rd\":" "*03:00 in America/Havana* (possibly, Friday, February 03)")
+
+  , testCase "Full date" $ mkTestCase arbitraryTime2 "10am in Europe/Helsinki 3rd February" userMoscow userHavana
+      -- sure
+      (mkBlocks "\"10am in Europe/Helsinki 3rd February\":" "*11:00 in Europe/Moscow, Friday, February 03*")
+      (mkBlocks "\"10am in Europe/Helsinki 3rd February\":" "*03:00 in America/Havana, Friday, February 03*")
+
+  , TestGroup "Invalid date"
+    [ testCase "Implicit timezone" $ mkTestCase havanaTime1 "0:30 tomorrow" userHavana userMoscow
+      (mkBlocksWithNote
+        [int||"0:30 tomorrow" in America/Havana:|]
+        [int||*invalid because of the time shift*|]
+        [int|n|_There is a timeshift in your timezone (America/Havana) around the
+        specified time and this particular timestamp does not exist, please \
+        define the offset explicitly._|])
+      (mkBlocksWithNote
+        [int||"0:30 tomorrow" in America/Havana:|]
+        [int||*invalid because of the time shift*|]
+        [int|n|_There is a time zone shift in the sender's timezone (America/Havana)
+        around that time, and this particular timestamp does not exist._|])
+    , testCase "Explicit timezone" $ mkTestCase havanaTime1 "0:30 in America/Havana tomorrow" userHavana userMoscow
+      (mkBlocksWithNote
+        [int||"0:30 in America/Havana tomorrow":|]
+        [int||*invalid because of the time shift*|]
+        [int|n|_There is a timeshift in America/Havana around the
+        specified time and this particular timestamp does not exist, please \
+        define the offset explicitly._|])
+      (mkBlocksWithNote
+        [int||"0:30 in America/Havana tomorrow":|]
+        [int||*invalid because of the time shift*|]
+        [int|n|_There is a time zone shift in America/Havana
+        around that time, and this particular timestamp does not exist._|])
+    ]
+
+  , TestGroup "Ambiguous date"
+    [ testCase "Implicit timezone" $ mkTestCase havanaTime2 "0:30 tomorrow" userHavana userMoscow
+      (mkBlocksWithNote
+        [int||"0:30 tomorrow" in America/Havana:|]
+        [int||*ambiguous because of the time shift*|]
+        [int|n|_There is a timeshift in your timezone (America/Havana) around the
+        specified time and this particular timestamp can be possible with
+        different offsets, please define the offset explicitly._|])
+      (mkBlocksWithNote
+        [int||"0:30 tomorrow" in America/Havana:|]
+        [int||*ambiguous because of the time shift*|]
+        [int|n|_There is a time zone shift in the sender's timezone (America/Havana)
+        around that time, and this particular timestamp
+        can be possible with different offsets._|])
+    , testCase "Explicit timezone" $ mkTestCase havanaTime2 "0:30 in America/Havana tomorrow" userHavana userMoscow
+      (mkBlocksWithNote
+        [int||"0:30 in America/Havana tomorrow":|]
+        [int||*ambiguous because of the time shift*|]
+        [int|n|_There is a timeshift in America/Havana around the
+        specified time and this particular timestamp can be possible with
+        different offsets, please define the offset explicitly._|])
+      (mkBlocksWithNote
+        [int||"0:30 in America/Havana tomorrow":|]
+        [int||*ambiguous because of the time shift*|]
+        [int|n|_There is a time zone shift in America/Havana
+        around that time, and this particular timestamp
+        can be possible with different offsets._|])
+    ]
+  ]
+
+mkBlocks :: Text -> Text -> [Block]
+mkBlocks timeRef translation =
+  singleton $ BSection $ (fieldsSection Nothing Nothing $ NE.singleton (Mrkdwn timeRef, Mrkdwn translation))
+
+mkBlocksWithNote :: Text -> Text -> Text -> [Block]
+mkBlocksWithNote timeRef translation note =
+  [ BSection $ (fieldsSection Nothing Nothing $ NE.singleton (Mrkdwn timeRef, Mrkdwn translation))
+  , BSection $ flip markdownSection Nothing $ Mrkdwn note
+  ]
+
+mkTestCase :: UTCTime -> Text -> User -> User -> [Block] -> [Block] -> Assertion
+mkTestCase eventTimestamp refText sender otherUser expectedSenderBlocks expectedOtherUserBlocks = do
+  let [timeRef] = parseTimeRefs refText
+      ephemeralTemplate =
+        renderTemplate asForMessageM eventTimestamp sender $
+          NE.singleton timeRef
+
+      getBlocks senderFlag user = maybe [] (renderSlackBlocks senderFlag . Just) $ renderAllTP user ephemeralTemplate
+      senderBlocks = getBlocks asForSenderS sender
+      otherUserBlocks = getBlocks asForOthersS otherUser
+  senderBlocks @?= expectedSenderBlocks
+  otherUserBlocks @?= expectedOtherUserBlocks

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -299,6 +299,7 @@ test-suite tzbot-test
       Test.TzBot.ConfigSpec
       Test.TzBot.HandleTooManyRequests
       Test.TzBot.MessageBlocksSpec
+      Test.TzBot.RenderSpec
       Test.TzBot.TimeReferenceToUtcSpec
       Tree
       Paths_tzbot

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -33,6 +33,7 @@ library
       TzBot.Feedback.Dialog.Types
       TzBot.Feedback.Save
       TzBot.Instances
+      TzBot.Logger
       TzBot.Options
       TzBot.Parser
       TzBot.ProcessEvents
@@ -129,8 +130,11 @@ library
     , http-client
     , http-client-tls
     , http-types
+    , katip
+    , lens
     , lens-aeson
     , lifted-async
+    , lifted-base
     , managed
     , megaparsec
     , monad-control
@@ -361,6 +365,7 @@ test-suite tzbot-test
     , containers
     , hspec
     , http-types
+    , katip
     , nyan-interpolation
     , servant-client-core
     , string-conversions


### PR DESCRIPTION
## Description

Problem: In many cases we can't know the full date because we are not
able to get all the context of the time reference. In such situations we
should explain the user somehow that we are not 100% sure in the
inferred date.
    
Solution: Implement simple guessing logic; we are either totally sure or
sure only about time, output messages are changed correspondingly.

Also done: slightly changed messages sending according to [requirements](https://www.notion.so/serokell/Requirements-7dc47068a206498989c4b899a767d208): ephemeral is also sent to the sender himself if the message contains time references in another timezone than the sender's one.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #36 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
