### PR TITLE
[#22] Revise messages editing

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -72,6 +72,7 @@ library:
   - utf8-string
   - validation
   - yaml
+  - utf8-string
 
 executables:
   tzbot-exe:

--- a/src/TzBot/Feedback/Dialog.hs
+++ b/src/TzBot/Feedback/Dialog.hs
@@ -20,7 +20,7 @@ import TzBot.RunMonad (BotM, BotState(bsReportEntries))
 insertDialogEntry :: ReportDialogId -> ReportDialogEntry -> BotM ()
 insertDialogEntry id_ entry = do
   dialogEntriesCache <- asks bsReportEntries
-  Cache.insertRandomized id_ entry dialogEntriesCache
+  Cache.insert id_ entry dialogEntriesCache
 
 lookupDialogEntry :: ReportDialogId -> BotM (Maybe ReportDialogEntry)
 lookupDialogEntry id_ = do

--- a/src/TzBot/Logger.hs
+++ b/src/TzBot/Logger.hs
@@ -14,6 +14,7 @@ import Universum
 
 import Data.Aeson (KeyValue((.=)), ToJSON(..), object)
 import Katip
+import Text.Interpolation.Nyan (int, rmode's)
 
 import TzBot.Slack.API (MessageId(..))
 
@@ -25,6 +26,9 @@ logInfo t = withFrozenCallStack $ logSugar_ InfoS t
 logWarn t = withFrozenCallStack $ logSugar_ WarningS t
 logDebug t = withFrozenCallStack $ logSugar_ DebugS t
 logError t = withFrozenCallStack $ logSugar_ ErrorS t
+
+logException :: (Exception e, KatipContext m) => e -> m ()
+logException err = logError [int||Error occured: #s{err}|]
 
 withLogger
   :: Severity

--- a/src/TzBot/ProcessEvents.hs
+++ b/src/TzBot/ProcessEvents.hs
@@ -87,8 +87,6 @@ handler shutdownRef bState _cfg e = run $ do
     run action = void $ runBotM bState $ do
       eithRes <- catchAllErrors action
       whenLeft eithRes $ \eithErr -> do
-        let logException :: (Exception e) => e -> BotM ()
-            logException err = logError [int||Error occured: #s{err}|]
         case eithErr of
           Left someExc
             | Just UserInterrupt <- fromException someExc ->

--- a/src/TzBot/Render.hs
+++ b/src/TzBot/Render.hs
@@ -128,7 +128,7 @@ renderSlackBlocks forSender =
       let t = (Mrkdwn $ tuTimeRef timeRef, Mrkdwn $ tuTranslation timeRef)
           mbNote = chooseNote forSender timeRef
           translationBlock = BSection $ fieldsSection Nothing $ NE.singleton t
-          mkNoteBlock note = BSection $ markdownSection (Mrkdwn note)
+          mkNoteBlock note = BSection $ markdownSection $ Mrkdwn note
       withMaybe mbNote [translationBlock] $ \note -> [translationBlock, mkNoteBlock note]
 
 renderTemplate :: UTCTime -> User -> NE.NonEmpty TimeReference -> Template

--- a/src/TzBot/RunMonad.hs
+++ b/src/TzBot/RunMonad.hs
@@ -10,7 +10,6 @@ import Control.Lens (makeLensesWith)
 import Control.Monad.Base (MonadBase)
 import Control.Monad.Except (MonadError)
 import Control.Monad.Trans.Control (MonadBaseControl)
-import Data.Map qualified as M
 import Data.Set qualified as S
 import Katip qualified as K
 import Network.HTTP.Client (Manager)
@@ -33,12 +32,11 @@ data BotState = BotState
   { bsConfig         :: BotConfig
   , bsManager        :: Manager
   , bsFeedbackConfig :: FeedbackConfig
-  -- TODO: after #22 bsMessagesReferences should either disappear or become
-  -- cached (not IORef).
-  , bsMessagesReferences :: IORef (M.Map MessageId (S.Set TimeReferenceText))
   , bsUserInfoCache  :: TzCache UserId User
   , bsConversationMembersCache :: TzCache ChannelId (S.Set UserId)
   , bsReportEntries  :: TzCache ReportDialogId ReportDialogEntry
+  , bsMessageCache   :: TzCache MessageId [TimeReference]
+  , bsMessageLinkCache :: TzCache MessageId Text
   , bsLogNamespace   :: K.Namespace
   , bsLogContext     :: K.LogContexts
   , bsLogEnv         :: K.LogEnv

--- a/src/TzBot/Slack/API.hs
+++ b/src/TzBot/Slack/API.hs
@@ -117,6 +117,12 @@ type API =
     :> "views.update"
     :> ReqBody '[JSON] UpdateViewReq
     :> Post '[JSON] (SlackResponse $ SlackContents "view" Value)
+  :<|>
+  Auth '[JWT] Text
+    :> "chat.getPermalink"
+    :> RequiredParam "channel" ChannelId
+    :> RequiredParam "message_ts" MessageId
+    :> Get '[JSON] (SlackResponse $ SlackContents "permalink" Text)
 
 api :: Proxy API
 api = Proxy
@@ -192,7 +198,7 @@ newtype ThreadId = ThreadId { unThreadId :: Text }
 
 newtype MessageId = MessageId { unMessageId :: Text }
   deriving stock (Eq, Show, Ord)
-  deriving newtype (ToHttpApiData, FromJSON, ToJSON, Buildable)
+  deriving newtype (ToHttpApiData, FromJSON, ToJSON, Buildable, Hashable)
 
 newtype Limit = Limit { limitQ :: Int}
   deriving stock (Eq, Show)

--- a/src/TzBot/Util.hs
+++ b/src/TzBot/Util.hs
@@ -192,3 +192,6 @@ catchAllErrors action = fmap reorder $ try $ tryError action
   reorder (Left e) = Left (Left e)
   reorder (Right (Left e)) = Left (Right e)
   reorder (Right (Right r)) = Right r
+
+whenT :: (Applicative m) => Bool -> m Bool -> m Bool
+whenT cond_ action_ = if cond_ then action_ else pure False


### PR DESCRIPTION
Problem: Currently message_changed event is handled by translating new time references and sending ephemeral with them, which can be inconvenient sometimes.

Solution: On message_changed event send an ephemeral containing message permalink and all message time references translated.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #22

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
