### PR TITLE
[#51] Revise exceptions handling

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -43,12 +43,8 @@ library:
   - katip
   - lens
   - lens-aeson
-  - lifted-async
-  - lifted-base
   - managed
   - megaparsec
-  - monad-control
-  - mtl
   - nyan-interpolation
   - o-clock
   - random
@@ -65,9 +61,9 @@ library:
   - time
   - time-compat
   - transformers
-  - transformers-base
   - tz
   - tztime
+  - unliftio
   - unordered-containers
   - utf8-string
   - validation

--- a/src/TzBot/Cache.hs
+++ b/src/TzBot/Cache.hs
@@ -23,7 +23,6 @@ module TzBot.Cache
 
 import Universum
 
-import Control.Concurrent.Async.Lifted (withAsync)
 import Data.Cache (Cache)
 import Data.Cache qualified as Cache
 import Data.Cache.Internal qualified as CacheI
@@ -32,6 +31,7 @@ import Formatting (Buildable)
 import System.Clock (TimeSpec)
 import Text.Interpolation.Nyan (int, rmode')
 import Time (Hour, KnownDivRat, Nanosecond, Time(..), hour, threadDelay, toUnit)
+import UnliftIO.Async (withAsync)
 
 import TzBot.Logger (KatipContext, katipAddNamespace, logDebug)
 import TzBot.Util (multTimeSpec, randomTimeSpec, timeToTimespec, (+-))

--- a/src/TzBot/Util.hs
+++ b/src/TzBot/Util.hs
@@ -6,10 +6,7 @@ module TzBot.Util where
 
 import Universum hiding (last, try)
 
-import Control.Exception.Lifted
 import Control.Lens (LensRules, lensField, lensRules, mappingNamer)
-import Control.Monad.Except (MonadError(catchError))
-import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Aeson
 import Data.Aeson qualified as AeKey
 import Data.Aeson qualified as Aeson
@@ -175,23 +172,6 @@ lookup key ciStorage = H.lookup (CI.mk key) $ unCIStorage ciStorage
 ----
 postfixFields :: LensRules
 postfixFields = lensRules & lensField .~ mappingNamer (\n -> [n ++ "L"])
-
-----
--- not present in mtl-2.2.2
-tryError :: MonadError e m => m a -> m (Either e a)
-tryError action = (Right <$> action) `catchError` (pure . Left)
-
--- | This catches all the exceptions (including asynchronous ones).
-catchAllErrors
-  :: (MonadError e m, MonadBaseControl IO m)
-  => m a
-  -> m (Either (Either SomeException e) a)
-catchAllErrors action = fmap reorder $ try $ tryError action
-  where
-  reorder :: Either e1 (Either e2 a) -> Either (Either e1 e2) a
-  reorder (Left e) = Left (Left e)
-  reorder (Right (Left e)) = Left (Right e)
-  reorder (Right (Right r)) = Right r
 
 whenT :: (Applicative m) => Bool -> m Bool -> m Bool
 whenT cond_ action_ = if cond_ then action_ else pure False

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -135,12 +135,8 @@ library
     , katip
     , lens
     , lens-aeson
-    , lifted-async
-    , lifted-base
     , managed
     , megaparsec
-    , monad-control
-    , mtl
     , nyan-interpolation
     , o-clock
     , optparse-applicative
@@ -157,10 +153,10 @@ library
     , time
     , time-compat
     , transformers
-    , transformers-base
     , tz
     , tztime
     , universum
+    , unliftio
     , unordered-containers
     , utf8-string
     , validation


### PR DESCRIPTION
## Description
Problem: Currently we use `ExceptT BotException IO` which is inconvenient because both BotException, other sync exceptions and async exceptions should be handled separately.

Solution: Remove ExceptT, use UnliftIO for exceptions handling, also use UnliftIO for asyncs instead of monad-control.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #51

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
