### PR TITLE
[Fix] Slight refactor of render part

### DIFF
--- a/src/TzBot/Feedback/Save.hs
+++ b/src/TzBot/Feedback/Save.hs
@@ -19,7 +19,7 @@ import Data.Time.Zones.All (toTZName)
 import Text.Interpolation.Nyan (int, rmode')
 
 import TzBot.Logger
-import TzBot.Render (TranslationPairs, renderSlackBlocks)
+import TzBot.Render (TranslationPairs, asForOthersS, renderSlackBlocks)
 import TzBot.RunMonad
 import TzBot.Slack (sendMessage)
 import TzBot.Slack.API
@@ -53,22 +53,21 @@ saveFeedbackSlack entry channelId = sendMessage req
     req = do
       -- We always render the translation for other users (not author),
       -- so the author can see how his message is translated for others
-      let forSender = False
-          pmrChannel = channelId
+      let pmrChannel = channelId
           pmrText = "New user feedback"
           pmrBlocks = NE.nonEmpty $
             [ BHeader (Header "Message")
-            , BSection (textSection (PlainText $ feMessageText entry) Nothing)
+            , BSection $ markdownSection (Mrkdwn $ feMessageText entry)
             , BDivider divider
             , BHeader (Header "Time translation")
-            ] <> renderSlackBlocks forSender (feTimeTranslation entry)
+            ] <> renderSlackBlocks asForOthersS (feTimeTranslation entry)
             <>
             [ BDivider divider
             , BHeader (Header "Details")
-            , BSection $ fieldsSection Nothing Nothing $
+            , BSection $ fieldsSection Nothing $
               ("Message timestamp", show $ feMessageTimestamp entry) :|
-              [ ("Sender timezone", PlainText $ cs $ toTZName $ feSenderTimezone entry)
-              , ("User report", PlainText $ feUserReport entry)
+              [ ("Sender timezone", Mrkdwn $ cs $ toTZName $ feSenderTimezone entry)
+              , ("User report", Mrkdwn $ feUserReport entry)
               ]
             ]
       PostMessageReq {..}

--- a/src/TzBot/Slack/API/Block.hs
+++ b/src/TzBot/Slack/API/Block.hs
@@ -12,7 +12,6 @@ module TzBot.Slack.API.Block
   , ActionId(..)
   , BlockId(..)
   , Section
-  , textSection
   , markdownSection
   , fieldsSection
   , Divider(..)
@@ -27,7 +26,7 @@ import Data.List.NonEmpty qualified as NE
 import Formatting (Buildable)
 
 import TzBot.Instances ()
-import TzBot.Slack.API.Common (Mrkdwn, PlainText, TextObject(TOMarkdownText, TOPlainText))
+import TzBot.Slack.API.Common (Mrkdwn(..), PlainText)
 import TzBot.Util (SumWrapper(..), TypedWrapper(..), neConcatMap)
 
 newtype ActionId = ActionId { unActionId :: Text }
@@ -51,21 +50,18 @@ data Block
 
 -- | See https://api.slack.com/reference/block-kit/blocks#section
 data Section = Section
-  { sText :: Maybe TextObject
+  { sText :: Maybe Mrkdwn
   , sAccessory :: Maybe Button
-  , sFields :: Maybe (NE.NonEmpty PlainText)
+  , sFields :: Maybe (NE.NonEmpty Mrkdwn)
   } deriving stock (Eq, Show, Generic)
     deriving ToJSON via TypedWrapper Section
 
-textSection :: PlainText -> Maybe Button -> Section
-textSection text mbButton = Section (Just $ TOPlainText text) mbButton Nothing
+markdownSection :: Mrkdwn -> Section
+markdownSection markdown = Section (Just markdown) Nothing Nothing
 
-markdownSection :: Mrkdwn -> Maybe Button -> Section
-markdownSection markdown mbButton = Section (Just $ TOMarkdownText markdown) mbButton Nothing
-
-fieldsSection :: Maybe TextObject -> Maybe Button -> NE.NonEmpty (PlainText, PlainText) -> Section
-fieldsSection mbText mbButton fields =
-  Section mbText mbButton $ Just $ neConcatMap (\(x, y) -> x :| [y]) fields
+fieldsSection :: Maybe Mrkdwn -> NE.NonEmpty (Mrkdwn, Mrkdwn) -> Section
+fieldsSection mbText fields =
+  Section mbText Nothing $ Just $ neConcatMap (\(x, y) -> x :| [y]) fields
 
 -- | See https://api.slack.com/reference/block-kit/blocks#divider
 data Divider = Divider

--- a/src/TzBot/Slack/Modal.hs
+++ b/src/TzBot/Slack/Modal.hs
@@ -10,7 +10,7 @@ import Data.List (singleton)
 
 import TzBot.Feedback.Dialog.Types
 import TzBot.Instances ()
-import TzBot.Render (TranslationPairs, renderSlackBlocks)
+import TzBot.Render (TranslationPairs, asForOthersS, renderSlackBlocks)
 import TzBot.Slack.API
 import TzBot.Slack.Fixtures qualified as Fixtures
 
@@ -64,13 +64,12 @@ mkBlocks :: Text -> Maybe TranslationPairs -> Block -> [Block]
 mkBlocks shownMessageText translatedMessage block =
   -- We always render the translation for other users (not author),
   -- so the author can see how his message is translated for others
-  let forSender = False in
   [ BHeader Header { hText = PlainText "Message text" }
-  , BSection $ textSection (PlainText shownMessageText) Nothing
+  , BSection $ markdownSection (Mrkdwn shownMessageText)
   , BDivider divider
   , BHeader Header { hText = PlainText "Time references" }
   ]
-  <> renderSlackBlocks forSender translatedMessage
+  <> renderSlackBlocks asForOthersS translatedMessage
   <> [ BDivider divider
   , block
   ]

--- a/test/Test/TzBot/TimeReferenceToUtcSpec.hs
+++ b/test/Test/TzBot/TimeReferenceToUtcSpec.hs
@@ -16,10 +16,6 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
 import TzBot.TimeReference
-  (DateReference(DayOfMonthRef, DayOfWeekRef, DaysFromToday),
-  LocationReference(OffsetRef, TimeZoneAbbreviationRef, TimeZoneRef), Offset(Offset),
-  TimeReference(TimeReference), TimeReferenceToUTCResult(..),
-  TimeZoneAbbreviation(TimeZoneAbbreviation), timeReferenceToUTC)
 
 time1 :: UTCTime
 time1 = toUTC [tz|2022-12-14 10:30:00 [Europe/Helsinki]|] -- Wednesday
@@ -61,7 +57,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-14 18:30:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-14 18:30:00 [UTC]|]) (Left label1)
           }
     , testCase "Tomorrow" $
         mkTestCase $ TestEntry
@@ -69,7 +65,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-15 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-15 06:00:00 [UTC]|]) (Left label1)
           }
     ]
   , testGroup "Time reference without location reference" $
@@ -80,7 +76,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-15 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-15 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of week, Wednesday -> Monday" $
         mkTestCase $ TestEntry
@@ -89,7 +85,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-19 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-19 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of week, Wednesday -> Friday" $
         mkTestCase $ TestEntry
@@ -98,7 +94,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-16 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-16 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of week, Wednesday -> Wednesday" $
         mkTestCase $ TestEntry
@@ -107,7 +103,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-14 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-14 06:00:00 [UTC]|]) (Left label1)
           }
 
     , testCase "Day of month, new year" $
@@ -117,7 +113,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2023-01-02 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2023-01-02 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of month, search for exactly matching candidate (not the closest)" $
         mkTestCase $ TestEntry
@@ -126,7 +122,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = toUTC [tz|2022-11-29 10:00:00 [Europe/Helsinki]|]
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-31 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-31 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of month, prefer past days if they are much closer" $
         mkTestCase $ TestEntry
@@ -135,7 +131,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = toUTC [tz|2022-12-03 10:00:00 [Europe/Helsinki]|]
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-11-25 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-11-25 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of month, prefer future days if they are slightly further" $
         mkTestCase $ TestEntry
@@ -144,7 +140,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = toUTC [tz|2022-12-03 10:00:00 [Europe/Helsinki]|]
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-22 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-22 06:00:00 [UTC]|]) (Left label1)
           }
 
     , testCase "Day of month and month of year, 1" $
@@ -154,7 +150,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2023-01-14 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2023-01-14 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of month and month of year, prefer future day if it's further" $
         mkTestCase $ TestEntry
@@ -163,7 +159,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = toUTC [tz|2022-06-15 10:00:00 [Europe/Helsinki]|]
           , teResult =
-              TRTUSuccess (toUTC [tz|2023-02-10 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2023-02-10 06:00:00 [UTC]|]) (Left label1)
           }
     , testCase "Day of month and month of year, prefer past day if it's much closer" $
         mkTestCase $ TestEntry
@@ -172,7 +168,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = toUTC [tz|2022-06-15 10:00:00 [Europe/Helsinki]|]
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-04-10 05:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-04-10 05:00:00 [UTC]|]) (Left label1)
           }
 
     , testCase "Time reference without location reference,\
@@ -183,7 +179,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-14 06:00:00 [UTC]|]) (Left label1)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-14 06:00:00 [UTC]|]) (Left label1)
           }
     ]
   , testCase "Custom time ref" $
@@ -194,7 +190,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-16 03:00:00 [UTC]|]) (Left Asia__Tashkent)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-16 03:00:00 [UTC]|]) (Left Asia__Tashkent)
           }
   , testCase "Explicit offset" $ do
       let offset = Offset $ 3 * hour
@@ -205,7 +201,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
           , teUserLabel = label1
           , teCurrentTime = time1
           , teResult =
-              TRTUSuccess (toUTC [tz|2022-12-16 05:00:00 [UTC]|]) (Right offset)
+              TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-16 05:00:00 [UTC]|]) (Right offset)
           }
   , testCase "Valid timezone abbreviation" $
       mkTestCase $ TestEntry
@@ -214,7 +210,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
         , teUserLabel = label1
         , teCurrentTime = time1
         , teResult =
-          TRTUSuccess (toUTC [tz|2022-12-16 05:00:00 [UTC]|]) (Right $ Offset $ 3 * hour)
+          TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-12-16 05:00:00 [UTC]|]) (Right $ Offset $ 3 * hour)
         }
   , testCase "Invalid timezone abbreviation" $
       mkTestCase $ TestEntry
@@ -233,7 +229,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
                 (Just $ DaysFromToday 2) (Just $ TimeZoneRef labelHavana)
           , teUserLabel = labelHavana
           , teCurrentTime = time2
-          , teResult = TRTUInvalid False labelHavana
+          , teResult = TRTUInvalid $ TimeShiftErrorInfo False labelHavana
           }
     , testCase "Turn on DST, explicit offset, Havana, Cuba" $ do
         let offset = Offset $ hour * (-5)
@@ -243,7 +239,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
                 (Just $ DaysFromToday 2) (Just $ OffsetRef offset)
           , teUserLabel = labelHavana
           , teCurrentTime = time2
-          , teResult = TRTUSuccess (toUTC [tz|2022-03-13 05:30:00 [UTC]|]) (Right offset)
+          , teResult = TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-03-13 05:30:00 [UTC]|]) (Right offset)
           }
     , testCase "Turn on DST, explicit offset abbreviation, Havana, Cuba" $ do
         let offset = Offset $ hour * (-5)
@@ -253,7 +249,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
                 (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "CDT")
           , teUserLabel = labelHavana
           , teCurrentTime = time2
-          , teResult = TRTUSuccess (toUTC [tz|2022-03-13 05:30:00 [UTC]|]) (Right offset)
+          , teResult = TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-03-13 05:30:00 [UTC]|]) (Right offset)
           }
     , testCase "Turn off DST, explicit time zone, Havana, Cuba" $
         mkTestCase $ TestEntry
@@ -262,7 +258,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
                 (Just $ DaysFromToday 2) (Just $ TimeZoneRef labelHavana)
           , teUserLabel = labelHavana
           , teCurrentTime = time3
-          , teResult = TRTUAmbiguous False labelHavana
+          , teResult = TRTUAmbiguous $ TimeShiftErrorInfo False labelHavana
           }
     , testCase "Turn off DST, explicit offset, Havana, Cuba" $ do
         let offset = Offset $ hour * (-5)
@@ -272,7 +268,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
                 (Just $ DaysFromToday 2) (Just $ OffsetRef offset)
           , teUserLabel = labelHavana
           , teCurrentTime = time3
-          , teResult = TRTUSuccess (toUTC [tz|2022-11-06 05:30:00 [UTC]|]) (Right offset)
+          , teResult = TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-11-06 05:30:00 [UTC]|]) (Right offset)
           }
     , testCase "Turn off DST, explicit offset abbreviation, Havana, Cuba" $ do
         let offset = Offset $ hour * (-5)
@@ -282,7 +278,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
                 (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "CDT")
           , teUserLabel = labelHavana
           , teCurrentTime = time3
-          , teResult = TRTUSuccess (toUTC [tz|2022-11-06 05:30:00 [UTC]|]) (Right offset)
+          , teResult = TRTUSuccess $ TimeRefSuccess (toUTC [tz|2022-11-06 05:30:00 [UTC]|]) (Right offset)
           }
     ]
   ]


### PR DESCRIPTION
## Description
We are going to work hard on translate/render modules and I would like some refactor to be present in all of that PRs beforehand.

Changes:
1. Remove button from section builders as it's never needed;
2. Add separate datatype for sender flag instead of plain Bool;
3. Replace plain text with markdown in the Slack section block;
4. Add functions for converting to offset time/back;
5. Unite fields of TimeReferenceToUtcResult for convenience.



<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
