### PR TITLE
[#36] Append inferred date parts

### DIFF
--- a/src/TzBot/Slack/API.hs
+++ b/src/TzBot/Slack/API.hs
@@ -173,7 +173,7 @@ instance (KnownSymbol key, FromJSON a) => FromJSON (SlackContents key a) where
 
 newtype UserId = UserId { unUserId :: Text }
   deriving stock (Eq, Ord, Show)
-  deriving newtype (ToHttpApiData, FromJSON, ToJSON, Hashable, Buildable)
+  deriving newtype (ToHttpApiData, FromJSON, ToJSON, Hashable, Buildable, IsString)
 
 newtype ChannelId = ChannelId { unChannelId :: Text }
   deriving stock (Eq, Show)

--- a/test/Test/TzBot/RenderSpec.hs
+++ b/test/Test/TzBot/RenderSpec.hs
@@ -1,0 +1,89 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Test.TzBot.RenderSpec
+  ( test_renderSpec
+  ) where
+
+import Universum
+
+import Data.List.NonEmpty qualified as NE
+import Data.Time (UTCTime)
+import Data.Time.TZInfo (TZLabel(..))
+import Data.Time.TZTime (toUTC)
+import Data.Time.TZTime.QQ (tz)
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+import Test.Tasty.Runners (TestTree(..))
+import TzBot.Parser (parseTimeRefs)
+import TzBot.Render
+import TzBot.Slack.API (User(..))
+
+-- Sunday
+arbitraryTime1 :: UTCTime
+arbitraryTime1 = toUTC [tz|2023-01-30 00:30:00 [Europe/Moscow]|]
+
+userMoscow :: User
+userMoscow = User {uId="msk1", uIsBot=False, uTz=Europe__Moscow}
+
+userHavana :: User
+userHavana = User {uId="hav", uIsBot=False, uTz=America__Havana}
+
+test_renderSpec :: TestTree
+test_renderSpec = TestGroup "Render" $
+  [ testCase "Implicit sender's timezone" $
+    mkTestCase arbitraryTime1 "10am" userMoscow userHavana
+    [ translWithoutNotes
+        "\"10am\", 30 January 2023 in Europe/Moscow"
+        "02:00, Monday, 30 January 2023 in America/Havana"
+    ]
+
+  , testCase "Implicit day" $
+    mkTestCase arbitraryTime1 "10am in Europe/Helsinki" userMoscow userHavana
+    [ translWithoutNotes
+        "\"10am in Europe/Helsinki\", 30 January 2023"
+        "03:00, Monday, 30 January 2023 in America/Havana"
+    ]
+
+  , testCase "Everything explicit" $
+    mkTestCase arbitraryTime1 "10am in America/Havana 3 Feb" userMoscow userHavana
+    [ translWithoutNotes
+        "\"10am in America/Havana 3 Feb\""
+        "10:00, Friday, 03 February 2023 in America/Havana"
+    ]
+  , testCase "Implicit timezone & implicit date & explicit weekday" $
+    mkTestCase arbitraryTime1 "10am on wednesday" userMoscow userHavana
+    [ translWithoutNotes
+        "\"10am on wednesday\", 01 February 2023 in Europe/Moscow"
+        "02:00, Wednesday, 01 February 2023 in America/Havana"
+    ]
+  , testCase "Implicit timezone & implicit date & explicit days from today" $
+    mkTestCase arbitraryTime1 "10am in 3 days" userMoscow userHavana
+    [ translWithoutNotes
+        "\"10am in 3 days\", 02 February 2023 in Europe/Moscow"
+        "02:00, Thursday, 02 February 2023 in America/Havana"
+    ]
+  , testCase "Implicit timezone & explicit day & implicit month" $
+    mkTestCase arbitraryTime1 "10am on the 21st" userMoscow userHavana
+    [ translWithoutNotes
+        "\"10am on the 21st\", 21 January 2023 in Europe/Moscow"
+        "02:00, Saturday, 21 January 2023 in America/Havana"
+    ]
+  ]
+
+translWithoutNotes :: Text -> Text -> TranslationPair
+translWithoutNotes q w = TranslationPair q w Nothing Nothing
+
+mkTestCase :: UTCTime -> Text -> User -> User -> [TranslationPair] -> Assertion
+mkTestCase eventTimestamp refText sender otherUser expectedOtherUserTransl = do
+  let [timeRef] = parseTimeRefs refText
+      ephemeralTemplate =
+        renderTemplate eventTimestamp sender $
+          NE.singleton timeRef
+
+      getTranslationPairs user =
+          renderAllForOthersTP user ephemeralTemplate
+      otherUserTransl = getTranslationPairs otherUser
+  toList otherUserTransl @?= expectedOtherUserTransl

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -297,6 +297,7 @@ test-suite tzbot-test
       Test.TzBot.ConfigSpec
       Test.TzBot.HandleTooManyRequests
       Test.TzBot.MessageBlocksSpec
+      Test.TzBot.RenderSpec
       Test.TzBot.TimeReferenceToUtcSpec
       Tree
       Paths_tzbot


### PR DESCRIPTION
## Description

Problem: Full date is not shown for the original time reference, which
can be useful for receivers.
    
Solution: Append inferred parts of the date to the quoted original time
reference text.


## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #36 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
