### PR TITLE
[#36] Warn user on possible timeshifts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,8 @@ steps:
 
   - label: stylish
     command: nix build -L .#checks.x86_64-linux.stylish-haskell
+    soft_fail:
+      - exit_status: 1
 
   - label: lint
     command: nix build -L .#checks.x86_64-linux.hlint

--- a/src/TzBot/TZ.hs
+++ b/src/TzBot/TZ.hs
@@ -1,0 +1,116 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module TzBot.TZ
+  ( TimeShift (..)
+  , checkForTimeshifts
+  , checkForTimeshifts'
+  ) where
+
+import Universum
+
+import Data.Bits (shiftR)
+import Data.List qualified
+import Data.Time (TimeZone(TimeZone, timeZoneMinutes), UTCTime, addUTCTime, nominalDay)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Data.Time.TZInfo (TZInfo(..), TZLabel(..))
+import Data.Time.TZInfo qualified as TZI
+import Data.Time.Zones (TZ)
+import Data.Time.Zones.Internal (utcTimeToInt64)
+import Data.Time.Zones.Types (TZ(..))
+import Data.Vector qualified as VB
+import Data.Vector.Unboxed qualified as VU
+
+import Data.List (nub)
+import TzBot.TimeReference (DateReference(..), TimeRefSuccess(..), TimeReference(..))
+import TzBot.Util (NamedOffset, Offset(..))
+
+-- | Represents a specific change in offset.
+data TimeShift = TimeShift
+  { tsShiftUtc :: UTCTime
+  -- ^ The time at which the offset change occurred / will occur.
+  , tsBefore   :: Offset
+  -- ^ The offset before the change.
+  , tsAfter    :: Offset
+  -- ^ The offset after the change.
+  , tsTzInfo   :: TZI.TZInfo
+  -- ^ The rules for the time zone where this change occurs.
+  } deriving stock (Eq, Show)
+
+-- | See the "Time shift warnings" section in `docs/development.md`.
+-- Sometimes the user does not specify a date, and we have to infer which date he meant.
+--
+-- When we do this, we should check if there were any time shifts around the inferred date,
+-- in either the "source" time zone or the receiver's time zone,
+-- and, if so, emit a warning.
+checkForTimeshifts :: TimeReference -> TimeRefSuccess -> TZLabel -> [TimeShift]
+checkForTimeshifts TimeReference{trDateRef} TimeRefSuccess{trsUtcResult, trsTzInfo} receiverTzLabel =
+  case trDateRef of
+    -- The date was inferred: we should check if there were any time shifts 3 days before/after the inferred date.
+    Nothing ->
+      checkEachTimeZone
+        (trsUtcResult & addUTCTime (nominalDay * -3))
+        (trsUtcResult & addUTCTime (nominalDay * 3))
+    -- The user specified the day of week; we had to infer which week they meant.
+    --
+    -- It's possible they meant "last week" instead, so we should check if
+    -- there were any time shifts between last week and the date we inferred.
+    Just (DayOfWeekRef {}) ->
+      checkEachTimeZone
+        (trsUtcResult & addUTCTime (nominalDay * -7))
+        trsUtcResult
+    -- The date was specified by the user; no need to perform the "time shift check"
+    Just (DaysFromToday {}) -> []
+    Just (DayOfMonthRef {}) -> []
+  where
+    -- Check for time shifts in both the "source" time zone and the receiver's time zone.
+    checkEachTimeZone :: UTCTime -> UTCTime -> [TimeShift]
+    checkEachTimeZone lowerBound upperBound =
+      nub [trsTzInfo, TZI.fromLabel receiverTzLabel]
+        & concatMap \tz -> checkForTimeshifts' tz lowerBound upperBound
+
+checkForTimeshifts' :: TZInfo -> UTCTime -> UTCTime -> [TimeShift]
+checkForTimeshifts' tzInfo (utcTimeToInt64 -> before) (utcTimeToInt64 -> after)
+  | before > after = []
+  | otherwise = do
+  let tz@(TZ trans _ _) = tziRules tzInfo
+      ixb = binarySearch trans before
+      startingFromIxb = VU.unsafeDrop ixb trans
+      desiredTimeshifts = zip [ixb..] $
+        takeWhile (<= after) $ VU.toList startingFromIxb
+      timeZones =
+        flip map desiredTimeshifts (\(ix, int64utc) ->
+          ( int64ToUtcTime int64utc
+          , Offset $ timeZoneMinutes $ timeZoneForIx tz ix)
+          )
+      timeShifts = zip timeZones $ Data.List.tail timeZones
+  map (\((_ub, b), (ua, a)) -> TimeShift ua b a tzInfo) timeShifts
+
+int64ToUtcTime :: Int64 -> UTCTime
+int64ToUtcTime = posixSecondsToUTCTime . fromIntegral
+{-# INLINE int64ToUtcTime #-}
+
+-- | Copied from "Data.Time.Zones" module of `tz` package because not exported.
+timeZoneForIx :: TZ -> Int -> NamedOffset
+timeZoneForIx (TZ _ diffs infos) i = TimeZone diffMins isDst name
+  where
+    diffMins = VU.unsafeIndex diffs i `div` 60
+    (isDst, name) = VB.unsafeIndex infos i
+{-# INLINE timeZoneForIx #-}
+
+-- | Copied from "Data.Time.Zones" module of `tz` package because not exported.
+-- Returns the largest index `i` such that `v ! i <= t`.
+--
+-- Assumes that `v` is sorted, has at least one element and `v ! 0 <= t`.
+binarySearch :: (VU.Unbox a, Ord a) => VU.Vector a -> a -> Int
+binarySearch v t | n == 1    = 0
+                 | otherwise = t `seq` go 1 n
+  where
+    n = VU.length v
+    go !l !u | l >= u = (l - 1)
+             | VU.unsafeIndex v k <= t  = go (k+1) u
+             | otherwise  = go l k
+      where
+        k = (l + u) `shiftR` 1
+{-# INLINE binarySearch #-}

--- a/test/Test/TzBot/GetTimeshiftsSpec.hs
+++ b/test/Test/TzBot/GetTimeshiftsSpec.hs
@@ -1,0 +1,139 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module Test.TzBot.GetTimeshiftsSpec
+  ( test_getTimeshiftsSpec
+  , test_checkForTimeshifts
+  ) where
+
+import Universum
+
+import Data.Time (UTCTime)
+import Data.Time.TZInfo (TZLabel(..))
+import Data.Time.TZInfo qualified as TZI
+import Data.Time.TZTime (toUTC)
+import Data.Time.TZTime.QQ (tz)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase, (@?=))
+import Text.Interpolation.Nyan
+
+import TzBot.Parser (parseTimeRefs)
+import TzBot.TZ (TimeShift(..), checkForTimeshifts, checkForTimeshifts')
+import TzBot.TimeReference (TimeReferenceToUTCResult(..), timeReferenceToUTC)
+import TzBot.Util
+
+springHavana2022utc, autumnHavana2022utc, springHavana2023utc :: UTCTime
+-- https://www.timeanddate.com/time/change/cuba/havana?year=2022
+springHavana2022utc = toUTC [tz|2022-03-13 05:00:00 [UTC]|]
+autumnHavana2022utc = toUTC [tz|2022-11-06 05:00:00 [UTC]|]
+-- https://www.timeanddate.com/time/change/cuba/havana?year=2023
+springHavana2023utc = toUTC [tz|2023-03-12 05:00:00 [UTC]|]
+
+springHavana2022, autumnHavana2022, springHavana2023 :: TimeShift
+springHavana2022 = TimeShift springHavana2022utc cst cdt (TZI.fromLabel America__Havana)
+autumnHavana2022 = TimeShift autumnHavana2022utc cdt cst (TZI.fromLabel America__Havana)
+springHavana2023 = TimeShift springHavana2023utc cst cdt (TZI.fromLabel America__Havana)
+
+cst, cdt :: Offset
+cst = Offset ((-5)*60)
+cdt = Offset ((-4)*60)
+
+test_getTimeshiftsSpec :: TestTree
+test_getTimeshiftsSpec = testGroup "GetTimeshifts"
+  [ testCase "havana1" $ do
+      let t1 = toUTC [tz|2022-03-12 23:59:00 [America/Havana]|]
+      let t2 = toUTC [tz|2023-03-12 01:01:00 [America/Havana]|]
+      let ts = checkForTimeshifts' (TZI.fromLabel America__Havana) t1 t2
+      ts @?=
+        [springHavana2022, autumnHavana2022, springHavana2023]
+  , testCase "havana2" $ do
+      let t1 = toUTC [tz|2022-03-13 01:00:00 [America/Havana]|]
+      let t2 = toUTC [tz|2023-03-12 01:00:00 [America/Havana]|]
+      let ts = checkForTimeshifts' (TZI.fromLabel America__Havana) t1 t2
+      ts @?=
+        [autumnHavana2022, springHavana2023]
+  , testCase "utc" $ do
+      let t1 = toUTC [tz|1900-01-01 01:00:00 [UTC]|]
+      let t2 = toUTC [tz|2024-03-12 01:00:00 [UTC]|]
+      let ts = checkForTimeshifts' (TZI.fromLabel Etc__UTC) t1 t2
+      ts @?= []
+  , testCase "incorrect arguments" $ do
+      let t1 = toUTC [tz|1900-01-01 01:00:00 [UTC]|]
+      let t2 = toUTC [tz|2024-03-12 01:00:00 [UTC]|]
+      let ts = checkForTimeshifts' (TZI.fromLabel Etc__UTC) t2 t1
+      ts @?= []
+  ]
+
+test_checkForTimeshifts :: TestTree
+test_checkForTimeshifts =
+  testGroup "checkForTimeshifts"
+    [ testCase "When the date is not specified, check for offset changes up to 3 days after/before the inferred date" do
+        -- there's an offset change 2 days and 23 hours before the inferred date/time.
+        -- https://www.timeanddate.com/time/change/cuba/havana?year=2023
+        check
+          (toUTC [tz|2023-03-14 00:00:00 [America/Havana]|]) "23:00" America__Havana
+          Europe__Lisbon
+          [ TimeShift (toUTC [tz|2023-03-12 01:00:00 [America/Havana]|]) cst cdt (TZI.fromLabel America__Havana) ]
+
+        -- there's an offset change 3 days and 1 hour before, so we don't return it.
+        check
+          (toUTC [tz|2023-03-15 00:00:00 [America/Havana]|]) "01:00" America__Havana
+          Europe__Lisbon
+          []
+
+        -- there's an offset change 2 days and 23 hours after the inferred date/time.
+        -- https://www.timeanddate.com/time/change/cuba/havana?year=2023
+        check
+          (toUTC [tz|2023-03-09 00:00:00 [America/Havana]|]) "00:00" America__Havana
+          Europe__Lisbon
+          [ TimeShift (toUTC [tz|2023-03-12 01:00:00 [America/Havana]|]) cst cdt (TZI.fromLabel America__Havana) ]
+
+        -- there's an offset change 3 days and 1 hour after, so we don't return it.
+        check
+          (toUTC [tz|2023-03-08 00:00:00 [America/Havana]|]) "23:00" America__Havana
+          Europe__Lisbon
+          []
+    , testCase "When the sender specifies a day of week, check for offset changes during the week before the inferred date" do
+        -- We will infer "23:00 on Saturday" means 23:00 on 18 March.
+        -- There's an offset change 6 days and 23 hours before the inferred date/time.
+        check
+          (toUTC [tz|2023-03-14 00:00:00 [America/Havana]|]) "23:00 on Saturday" America__Havana
+          Europe__Lisbon
+          [ TimeShift (toUTC [tz|2023-03-12 01:00:00 [America/Havana]|]) cst cdt (TZI.fromLabel America__Havana) ]
+
+        -- We will infer "01:00 on Sunday" means 01:00 on 19 March.
+        -- There's an offset change 7 days and 1 hour before the inferred date/time, so we don't return it.
+        check
+          (toUTC [tz|2023-03-14 00:00:00 [America/Havana]|]) "01:00 on Sunday" America__Havana
+          Europe__Lisbon
+          []
+
+        -- We will infer "23:00 on Saturday" means 01:00 on 11 March.
+        -- There's an offset change 1 hour after the inferred date/time,
+        -- but we only check for offset changes in the past, so we don't return anything.
+        check
+          (toUTC [tz|2023-03-11 00:00:00 [America/Havana]|]) "23:00 on Saturday" America__Havana
+          Europe__Lisbon
+          []
+    ]
+  where
+    check :: UTCTime -> Text -> TZLabel -> TZLabel -> [TimeShift] -> Assertion
+    check now input senderTimeZone receiverTimeZone expectedTimeShifts = do
+      case parseTimeRefs input of
+        [timeRef] ->
+          case timeReferenceToUTC senderTimeZone now timeRef of
+            TRTUSuccess timeRefSuccess ->
+              checkForTimeshifts timeRef timeRefSuccess receiverTimeZone @?= expectedTimeShifts
+            other ->
+              assertFailure
+                [int|s|
+                  Expected 'timeReferenceToUTC' to success, but it failed:
+                  #s{other}
+                |]
+        timeRefs ->
+          assertFailure
+            [int|s|
+              Expected 'parseTimeRefs' to return exactly 1 result, but it returned:
+              #s{timeRefs}
+            |]

--- a/test/Test/TzBot/RenderSpec.hs
+++ b/test/Test/TzBot/RenderSpec.hs
@@ -17,16 +17,20 @@ import Data.Time.TZTime.QQ (tz)
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 import Test.Tasty.Runners (TestTree(..))
+
 import TzBot.Parser (parseTimeRefs)
 import TzBot.Render
-import TzBot.Slack.API (User(..))
+import TzBot.Slack.API
 
 -- Sunday
 arbitraryTime1 :: UTCTime
 arbitraryTime1 = toUTC [tz|2023-01-30 00:30:00 [Europe/Moscow]|]
 
+nearTimeshift :: UTCTime
+nearTimeshift = toUTC [tz|2023-03-11 00:30:00 [Europe/Moscow]|]
+
 userMoscow :: User
-userMoscow = User {uId="msk1", uIsBot=False, uTz=Europe__Moscow}
+userMoscow = User {uId="msk", uIsBot=False, uTz=Europe__Moscow}
 
 userMoscow2 :: User
 userMoscow2 = User {uId="msk2", uIsBot=False, uTz=Europe__Moscow}
@@ -119,6 +123,73 @@ test_renderSpec = TestGroup "Render"
           "You are in this timezone"
       ]
     ]
+
+  , TestGroup "TimeshiftWarning"
+    [ testCase "Implicit date" $
+      mkChatCase nearTimeshift "10am" userMoscow userHavana
+      [ translWithCommonNote
+          "\"10am\", 11 March 2023 in Europe/Moscow"
+          "02:00, Saturday, 11 March 2023 in America/Havana"
+          "_Warning: We inferred that \"10am\" refers to 11 March 2023 in Europe/Moscow and converted it to America/Havana, but there is a time change near this date_:\n  \8226 _At 00:00, 12 March 2023 in America/Havana, the clocks are turned forward 1 hour(s)_.\n_Beware that if this inference is not correct and the sender meant a different date, the conversion may not be accurate._"
+      ]
+    , testCase "Day of week" $
+      mkChatCase nearTimeshift "10am on sunday" userMoscow userHavana
+      [ translWithCommonNote
+          "\"10am on sunday\", 12 March 2023 in Europe/Moscow"
+          "03:00, Sunday, 12 March 2023 in America/Havana"
+          "_Warning: We inferred that \"10am on sunday\" refers to 12 March 2023 in Europe/Moscow and converted it to America/Havana, but there is a time change near this date_:\n  \8226 _At 00:00, 12 March 2023 in America/Havana, the clocks are turned forward 1 hour(s)_.\n_Beware that if this inference is not correct and the sender meant a different date, the conversion may not be accurate._"
+      ]
+    , testCase "Day of week, inversed users" $
+      mkChatCase nearTimeshift "10am on sunday" userHavana userMoscow
+      [ translWithCommonNote
+          "\"10am on sunday\", 12 March 2023 in America/Havana"
+          "17:00, Sunday, 12 March 2023 in Europe/Moscow"
+          "_Warning: We inferred that \"10am on sunday\" refers to 12 March 2023 in America/Havana and converted it to Europe/Moscow, but there is a time change near this date_:\n  \8226 _At 00:00, 12 March 2023 in America/Havana, the clocks are turned forward 1 hour(s)_.\n_Beware that if this inference is not correct and the sender meant a different date, the conversion may not be accurate._"
+      ]
+    , testCase "Timeshifts in both timezones" $
+      mkChatCase
+        (toUTC [tz|2023-03-25 15:00:00 [Europe/London]|])
+        "10am"
+        (User {uId="london", uIsBot=False, uTz=Europe__London})
+        (User {uId="lisbon", uIsBot=False, uTz=Europe__Lisbon})
+      [ translWithCommonNote
+          "\"10am\", 26 March 2023 in Europe/London"
+          "10:00, Sunday, 26 March 2023 in Europe/Lisbon"
+          "_Warning: We inferred that \"10am\" refers to 26 March 2023 in Europe/London and converted it to Europe/Lisbon, but there is a time change near this date_:\n  \8226 _At 01:00, 26 March 2023 in Europe/London, the clocks are turned forward 1 hour(s)_.\n  \8226 _At 01:00, 26 March 2023 in Europe/Lisbon, the clocks are turned forward 1 hour(s)_.\n_Beware that if this inference is not correct and the sender meant a different date, the conversion may not be accurate._"
+      ]
+    , TestGroup "ExplicitDate"
+      [ testCase "No warning: tomorrow" $
+        mkChatCase
+          (toUTC [tz|2023-03-25 15:00:00 [Europe/London]|])
+          "10am tomorrow"
+          (User {uId="london", uIsBot=False, uTz=Europe__London})
+          (User {uId="lisbon", uIsBot=False, uTz=Europe__Lisbon})
+        [ translWithoutNotes
+          "\"10am tomorrow\", 26 March 2023 in Europe/London"
+          "10:00, Sunday, 26 March 2023 in Europe/Lisbon"
+        ]
+      , testCase "No warning: 2 days ahead" $
+        mkChatCase
+          (toUTC [tz|2023-03-24 15:00:00 [Europe/London]|])
+          "10am 2 days ahead"
+          (User {uId="london", uIsBot=False, uTz=Europe__London})
+          (User {uId="lisbon", uIsBot=False, uTz=Europe__Lisbon})
+        [ translWithoutNotes
+          "\"10am 2 days ahead\", 26 March 2023 in Europe/London"
+          "10:00, Sunday, 26 March 2023 in Europe/Lisbon"
+        ]
+      , testCase "No warning: fully specified date" $
+        mkChatCase
+          (toUTC [tz|2023-03-24 15:00:00 [Europe/London]|])
+          "10am 26 march"
+          (User {uId="london", uIsBot=False, uTz=Europe__London})
+          (User {uId="lisbon", uIsBot=False, uTz=Europe__Lisbon})
+        [ translWithoutNotes
+          "\"10am 26 march\" in Europe/London"
+          "10:00, Sunday, 26 March 2023 in Europe/Lisbon"
+        ]
+      ]
+    ]
   ]
 
 translWithoutNotes :: Text -> Text -> TranslationPair
@@ -129,6 +200,9 @@ mkModalCase = mkTestCase asForModalM
 
 mkChatCase :: UTCTime -> Text -> User -> User -> [TranslationPair] -> Assertion
 mkChatCase = mkTestCase asForMessageM
+
+translWithCommonNote :: Text -> Text -> Text -> TranslationPair
+translWithCommonNote q w e = TranslationPair q w (Just e) (Just e)
 
 mkTestCase :: ModalFlag -> UTCTime -> Text -> User -> User -> [TranslationPair] -> Assertion
 mkTestCase modalFlag eventTimestamp refText sender otherUser expectedOtherUserTransl = do

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -55,6 +55,7 @@ library
       TzBot.Slack.Fixtures
       TzBot.Slack.Modal
       TzBot.TimeReference
+      TzBot.TZ
       TzBot.Util
   other-modules:
       Paths_tzbot
@@ -297,6 +298,7 @@ test-suite tzbot-test
   main-is: Main.hs
   other-modules:
       Test.TzBot.ConfigSpec
+      Test.TzBot.GetTimeshiftsSpec
       Test.TzBot.HandleTooManyRequests
       Test.TzBot.MessageBlocksSpec
       Test.TzBot.RenderSpec


### PR DESCRIPTION
## Description
Problem: In some cases the bot selects the date rather arbitrarily, and if a timeshift is somewhere around, the translation may be dependent on concrete date. We should warn a user about possible timeshifts.

Solution: For some types of date references, also compute a date range to check for the possible timeshift, and report to user if something found.



<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed part of #36

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
