### PR TITLE
[#53] Skip sending for matching timezones

### DIFF
--- a/src/TzBot/ProcessEvents/Common.hs
+++ b/src/TzBot/ProcessEvents/Common.hs
@@ -22,7 +22,7 @@ import TzBot.Feedback.Dialog (insertDialogEntry)
 import TzBot.Feedback.Dialog.Types
 import TzBot.Logger
 import TzBot.Parser (parseTimeRefs)
-import TzBot.Render (TranslationPairs, renderAllForOthersTP, renderTemplate)
+import TzBot.Render (TranslationPairs, asForModalM, renderAllTP, renderTemplate)
 import TzBot.Slack (BotM, getUserCached, startModal)
 import TzBot.Slack.API
 import TzBot.Slack.API.MessageBlock
@@ -47,11 +47,11 @@ openModalCommon message channelId whoTriggeredId triggerId mkModalFunc = do
       msgTimestamp = mTs message
   mbTimeRefs <- nonEmpty <$> getTimeReferencesFromMessage message
   sender <- getUserCached $ mUser message
-  translationPairs <- forM mbTimeRefs $ \neTimeRefs -> do
+  translationPairs <- fmap join $ forM mbTimeRefs $ \neTimeRefs -> do
       whoTriggered <- getUserCached whoTriggeredId
       pure $
-        renderAllForOthersTP whoTriggered $
-          renderTemplate msgTimestamp sender neTimeRefs
+        renderAllTP whoTriggered $
+          renderTemplate asForModalM msgTimestamp sender neTimeRefs
 
   guid <- ReportDialogId <$> liftIO genText
   let metadata = ReportDialogEntry
@@ -80,8 +80,9 @@ getTimeReferencesFromMessage message =
 -- structure, but since it's not documented it can not work sometimes,
 -- `ignoreCodeBlocksManually` is used a reserve function.
 getTextPiecesFromMessage
-  :: Message
-  -> BotM [Text]
+  :: (Monad m, KatipContext m)
+  => Message
+  -> m [Text]
 getTextPiecesFromMessage message = do
   let throwAwayTooShort = filter (\x -> T.compareLength x 2 == GT)
   throwAwayTooShort <$> case unUnknown $ msgBlocks message of

--- a/src/TzBot/Util.hs
+++ b/src/TzBot/Util.hs
@@ -8,7 +8,6 @@ import Universum hiding (last, try)
 
 import Control.Lens (LensRules, lensField, lensRules, mappingNamer)
 import Data.Aeson
-import Data.Aeson qualified as AeKey
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Casing
 import Data.Aeson.Key qualified as AeKey
@@ -21,10 +20,8 @@ import Data.String.Conversions (cs)
 import Data.Time (UTCTime, defaultTimeLocale, parseTimeM)
 import Data.Yaml qualified as Y
 import GHC.Generics
-import GHC.IO (unsafePerformIO)
 import Language.Haskell.TH
 import System.Clock (TimeSpec, fromNanoSecs, toNanoSecs)
-import System.Environment (lookupEnv)
 import System.Random (randomRIO)
 import Text.Interpolation.Nyan (int, rmode')
 import Time (KnownDivRat, Nanosecond, Time, floorRat, ns, toUnit)
@@ -139,13 +136,6 @@ neConcatMap func ns = foldr1 (<>) $ fmap func ns
 >>> neConcatMap (\x -> x :| [x + 1]) $ 1 :| [2,3]
 1 :| [2,2,3,3,4]
  -}
-
-----
-{-# NOINLINE isDevEnvironment #-}
-isDevEnvironment :: Bool
-isDevEnvironment = unsafePerformIO $ do
-  env <- lookupEnv "SLACK_TZ_DEVENV"
-  pure $ env == Just "true"
 
 ----
 stripPrefixIfPresent :: Eq a => [a] -> [a] -> [a]

--- a/test/Test/TzBot/RenderSpec.hs
+++ b/test/Test/TzBot/RenderSpec.hs
@@ -28,62 +28,95 @@ arbitraryTime1 = toUTC [tz|2023-01-30 00:30:00 [Europe/Moscow]|]
 userMoscow :: User
 userMoscow = User {uId="msk1", uIsBot=False, uTz=Europe__Moscow}
 
+userMoscow2 :: User
+userMoscow2 = User {uId="msk2", uIsBot=False, uTz=Europe__Moscow}
+
 userHavana :: User
 userHavana = User {uId="hav", uIsBot=False, uTz=America__Havana}
 
 test_renderSpec :: TestTree
-test_renderSpec = TestGroup "Render" $
-  [ testCase "Implicit sender's timezone" $
-    mkTestCase arbitraryTime1 "10am" userMoscow userHavana
-    [ translWithoutNotes
-        "\"10am\", 30 January 2023 in Europe/Moscow"
-        "02:00, Monday, 30 January 2023 in America/Havana"
-    ]
+test_renderSpec = TestGroup "Render"
+  [ TestGroup "RenderChar"
+    [ testCase "Implicit sender's timezone" $
+      mkChatCase arbitraryTime1 "10am" userMoscow userHavana
+      [ translWithoutNotes
+          "\"10am\", 30 January 2023 in Europe/Moscow"
+          "02:00, Monday, 30 January 2023 in America/Havana"
+      ]
 
-  , testCase "Implicit day" $
-    mkTestCase arbitraryTime1 "10am in Europe/Helsinki" userMoscow userHavana
-    [ translWithoutNotes
-        "\"10am in Europe/Helsinki\", 30 January 2023"
-        "03:00, Monday, 30 January 2023 in America/Havana"
-    ]
+    , testCase "Implicit day" $
+      mkChatCase arbitraryTime1 "10am in Europe/Helsinki" userMoscow userHavana
+      [ translWithoutNotes
+          "\"10am in Europe/Helsinki\", 30 January 2023"
+          "03:00, Monday, 30 January 2023 in America/Havana"
+      ]
 
-  , testCase "Everything explicit" $
-    mkTestCase arbitraryTime1 "10am in America/Havana 3 Feb" userMoscow userHavana
-    [ translWithoutNotes
-        "\"10am in America/Havana 3 Feb\""
-        "10:00, Friday, 03 February 2023 in America/Havana"
+    , testCase "Everything explicit" $
+      mkChatCase arbitraryTime1 "10am in Europe/Helsinki 3 Feb" userMoscow userHavana
+      [ translWithoutNotes
+          "\"10am in Europe/Helsinki 3 Feb\""
+          "03:00, Friday, 03 February 2023 in America/Havana"
+      ]
+    , testCase "Same timezone" $
+      mkChatCase arbitraryTime1 "10am" userMoscow userMoscow2
+      [ translWithoutNotes
+          "\"10am\", 30 January 2023 in Europe/Moscow"
+          "You are in this timezone"
+      ]
+    , testCase "Back to author, same timezone" $
+      mkChatCase arbitraryTime1 "10am" userMoscow userMoscow
+      []
+    , testCase "Back to author, other timezone" $
+      mkChatCase arbitraryTime1 "10am in Europe/Helsinki" userMoscow userMoscow
+      [ translWithoutNotes
+          "\"10am in Europe/Helsinki\", 30 January 2023"
+          "11:00, Monday, 30 January 2023 in Europe/Moscow"
+      ]
+    , testCase "Implicit timezone & implicit date & explicit weekday" $
+      mkChatCase arbitraryTime1 "10am on wednesday" userMoscow userHavana
+      [ translWithoutNotes
+          "\"10am on wednesday\", 01 February 2023 in Europe/Moscow"
+          "02:00, Wednesday, 01 February 2023 in America/Havana"
+      ]
+    , testCase "Implicit timezone & implicit date & explicit days from today" $
+      mkChatCase arbitraryTime1 "10am in 3 days" userMoscow userHavana
+      [ translWithoutNotes
+          "\"10am in 3 days\", 02 February 2023 in Europe/Moscow"
+          "02:00, Thursday, 02 February 2023 in America/Havana"
+      ]
+    , testCase "Implicit timezone & explicit day & implicit month" $
+      mkChatCase arbitraryTime1 "10am on the 21st" userMoscow userHavana
+      [ translWithoutNotes
+          "\"10am on the 21st\", 21 January 2023 in Europe/Moscow"
+          "02:00, Saturday, 21 January 2023 in America/Havana"
+      ]
     ]
-  , testCase "Implicit timezone & implicit date & explicit weekday" $
-    mkTestCase arbitraryTime1 "10am on wednesday" userMoscow userHavana
-    [ translWithoutNotes
-        "\"10am on wednesday\", 01 February 2023 in Europe/Moscow"
-        "02:00, Wednesday, 01 February 2023 in America/Havana"
-    ]
-  , testCase "Implicit timezone & implicit date & explicit days from today" $
-    mkTestCase arbitraryTime1 "10am in 3 days" userMoscow userHavana
-    [ translWithoutNotes
-        "\"10am in 3 days\", 02 February 2023 in Europe/Moscow"
-        "02:00, Thursday, 02 February 2023 in America/Havana"
-    ]
-  , testCase "Implicit timezone & explicit day & implicit month" $
-    mkTestCase arbitraryTime1 "10am on the 21st" userMoscow userHavana
-    [ translWithoutNotes
-        "\"10am on the 21st\", 21 January 2023 in Europe/Moscow"
-        "02:00, Saturday, 21 January 2023 in America/Havana"
+  , TestGroup "Modal"
+    [ testCase "Back to author, same timezone" $
+      mkModalCase arbitraryTime1 "10am" userMoscow userMoscow
+      [ translWithoutNotes
+          "\"10am\", 30 January 2023 in Europe/Moscow"
+          "You are in this timezone"
+      ]
     ]
   ]
 
 translWithoutNotes :: Text -> Text -> TranslationPair
 translWithoutNotes q w = TranslationPair q w Nothing Nothing
 
-mkTestCase :: UTCTime -> Text -> User -> User -> [TranslationPair] -> Assertion
-mkTestCase eventTimestamp refText sender otherUser expectedOtherUserTransl = do
+mkModalCase :: UTCTime -> Text -> User -> User -> [TranslationPair] -> Assertion
+mkModalCase = mkTestCase asForModalM
+
+mkChatCase :: UTCTime -> Text -> User -> User -> [TranslationPair] -> Assertion
+mkChatCase = mkTestCase asForMessageM
+
+mkTestCase :: ModalFlag -> UTCTime -> Text -> User -> User -> [TranslationPair] -> Assertion
+mkTestCase modalFlag eventTimestamp refText sender otherUser expectedOtherUserTransl = do
   let [timeRef] = parseTimeRefs refText
       ephemeralTemplate =
-        renderTemplate eventTimestamp sender $
+        renderTemplate modalFlag eventTimestamp sender $
           NE.singleton timeRef
 
-      getTranslationPairs user =
-          renderAllForOthersTP user ephemeralTemplate
+      getTranslationPairs user = renderAllTP user ephemeralTemplate
       otherUserTransl = getTranslationPairs otherUser
-  toList otherUserTransl @?= expectedOtherUserTransl
+  maybe [] toList otherUserTransl @?= expectedOtherUserTransl


### PR DESCRIPTION
## Description
Problem: Sometimes, when timezones in message and a receiver's one are the same, it's not required to actually translate anything because the original time reference is already relevant for the receiver.

Solution: for other users than sender, say "timezone is the same", for sender himself translate only time references that are in other timezones and ignore ones with his timezone, but translate everything when modal is triggered.



<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #53 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
