### PR TITLE
[#68] Flush feedback to the file immediately

### DIFF
--- a/src/TzBot/BotMain.hs
+++ b/src/TzBot/BotMain.hs
@@ -15,6 +15,7 @@ import Slacker
   (defaultSlackConfig, handleThreadExceptionSensibly, runSocketMode, setApiToken, setAppToken,
   setGracefulShutdownHandler, setOnException)
 import System.Directory (doesFileExist)
+import System.IO (BufferMode(..), hSetBuffering)
 import Text.Interpolation.Nyan (int, rmode')
 import Time (hour)
 
@@ -104,4 +105,7 @@ withFeedbackConfig Config {..} action = do
     withFeedbackFile :: Maybe FilePath -> (Maybe Handle -> IO a) -> IO a
     withFeedbackFile mbPath action =
       withMaybe mbPath (action Nothing) $ \path ->
-        withFile path AppendMode (action . Just)
+        withFile path AppendMode \handle -> do
+          -- Use `LineBuffering` so that feedback is flushed to the file immediately.
+          hSetBuffering handle LineBuffering
+          action $ Just handle

--- a/src/TzBot/Slack/Events.hs
+++ b/src/TzBot/Slack/Events.hs
@@ -39,7 +39,7 @@ data MessageDetails
   deriving stock (Eq, Show, Generic)
 
 instance FromJSON MessageEvent where
-  parseJSON = withObject "" $ \o -> do
+  parseJSON = withObject "MessageEvent" $ \o -> do
     meChannel <- o .: "channel"
     meChannelType <- o .:? "channel_type"
     meTs <- fetchSlackTimestamp "ts" o


### PR DESCRIPTION
## Description

Problem: Right now, we're using `withFile` to open a file handle to `feedback.log`. This seems to use `BlockBuffering` by default, which means feedback is not immediately written to the log file. This might take some time to be written to file or, worst case scenario, is only written when the application shuts down.

Solution: Use line buffering instead, so that output is flushed to the file as soon as a newline character is emitted.

Also took the opportunity to do a couple of small fixes: replace a usage of `withObject ""` with `withObject "MessageEvent"`, and pull dependencies from hackage instead of github repos.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #68

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
