### PR TITLE
[#70] Warn users on unrecognized timezone abbreviation

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -58,6 +58,7 @@ library:
   - string-conversions
   - template-haskell
   - text
+  - text-metrics
   - time
   - time-compat
   - transformers

--- a/test/Test/TzBot/RenderSpec.hs
+++ b/test/Test/TzBot/RenderSpec.hs
@@ -90,6 +90,20 @@ test_renderSpec = TestGroup "Render"
           "\"10am on the 21st\", 21 January 2023 in Europe/Moscow"
           "02:00, Saturday, 21 January 2023 in America/Havana"
       ]
+    , testCase "Unknown timezone abbreviation, no similar known ones" $
+      mkChatCase arbitraryTime1 "10am KAMAZ" userMoscow userHavana
+      [ translWithoutNotes
+        "\"10am KAMAZ\""
+        "Contains unrecognized timezone abbreviation: KAMAZ"
+      ]
+    , testCase "Unknown timezone abbreviation, some similar known ones" $
+      mkChatCase arbitraryTime1 "10am WETS" userMoscow userHavana
+      [ TranslationPair
+        "\"10am WETS\""
+        "Contains unrecognized timezone abbreviation: WETS"
+        (Just "_Maybe you meant: WET, WEST_")
+        Nothing
+      ]
     ]
   , TestGroup "Modal"
     [ testCase "Back to author, same timezone" $

--- a/test/Test/TzBot/TimeReferenceToUtcSpec.hs
+++ b/test/Test/TzBot/TimeReferenceToUtcSpec.hs
@@ -245,7 +245,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
   , testCase "Valid timezone abbreviation" $
       mkTestCase $ TestEntry
         { teTimeRef = TimeReference "" (TimeOfDay 8 0 0) (Just $ DaysFromToday 2)
-                      (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "MSK")
+                      (Just $ OffsetRef (Offset $ 3 * 60))
         , teUserLabel = label1
         , teCurrentTime = time1
         , teResult =
@@ -257,10 +257,10 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
       mkTestCase $ TestEntry
         { teTimeRef =
             TimeReference "" (TimeOfDay 8 0 0) (Just $ DaysFromToday 2)
-              (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "MKS")
+              (Just $ UnknownTimeZoneAbbreviationRef $ UnknownTimeZoneAbbrev "MKS" ["MSK"])
         , teUserLabel = label1
         , teCurrentTime = time1
-        , teResult = TRTUInvalidTimeZoneAbbrev "MKS"
+        , teResult = TRTUInvalidTimeZoneAbbrev $ UnknownTimeZoneAbbrev "MKS" ["MSK"]
         }
   , testGroup "Timeshift subtleties" $
     [ testCase "Turn on DST, explicit time zone, Havana, Cuba" $
@@ -289,7 +289,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
         mkTestCase $ TestEntry
           { teTimeRef =
               TimeReference "" (TimeOfDay 0 30 0) (Just $ DaysFromToday 2)
-                (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "CDT")
+                (Just $ OffsetRef (Offset ((-5) * 60)))
           , teUserLabel = labelHavana
           , teCurrentTime = time2
           , teResult = TRTUSuccess $ mkSuccessSameDate
@@ -322,7 +322,7 @@ test_TimeReferenceToUtc = testGroup "TimeReference to UTC" $
         mkTestCase $ TestEntry
           { teTimeRef =
               TimeReference "" (TimeOfDay 0 30 0) (Just $ DaysFromToday 2)
-                (Just $ TimeZoneAbbreviationRef $ TimeZoneAbbreviation "CDT")
+                (Just $ OffsetRef (Offset ((-5) * 60)))
           , teUserLabel = labelHavana
           , teCurrentTime = time3
           , teResult = TRTUSuccess $ mkSuccessSameDate

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -150,6 +150,7 @@ library
     , string-conversions
     , template-haskell
     , text
+    , text-metrics
     , time
     , time-compat
     , transformers


### PR DESCRIPTION
## Description
Problem: Currently, unrecognized timezone abbreviation is simply ignored as it would be an unrelated word.

Solution: Consider all-capitalized words with 2-5 characters length as timezone abbreviations and warn users when they are not known by us; add hints when encountered abbreviation is similar to some of known ones.



<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #70 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
