### PR TITLE
[#71] Explicitly state offset for abbrevs

### DIFF
--- a/src/TzBot/Render.hs
+++ b/src/TzBot/Render.hs
@@ -172,6 +172,9 @@ getOriginalTimeRef :: User -> TimeReference -> Day -> Text
 getOriginalTimeRef sender timeRef originalDay = do
   let mbSenderTimeZone :: Maybe Builder
       mbSenderTimeZone = case trLocationRef timeRef of
+        Just (TimeZoneAbbreviationRef TimeZoneAbbreviationInfo {..}) -> do
+          guard $ not $ tzaiAbbreviation `elem` ["UTC", "GMT"]
+          Just [int||, #{tzaiFullName} (#{tzaiOffsetMinutes}) |]
         Just _ -> Nothing
         Nothing -> Just [int|| in #{uTz sender}|]
       mbShownOriginalDate = case trDateRef timeRef of

--- a/test/Test/TzBot/RenderSpec.hs
+++ b/test/Test/TzBot/RenderSpec.hs
@@ -36,7 +36,7 @@ userHavana = User {uId="hav", uIsBot=False, uTz=America__Havana}
 
 test_renderSpec :: TestTree
 test_renderSpec = TestGroup "Render"
-  [ TestGroup "RenderChar"
+  [ TestGroup "RenderChat"
     [ testCase "Implicit sender's timezone" $
       mkChatCase arbitraryTime1 "10am" userMoscow userHavana
       [ translWithoutNotes
@@ -103,6 +103,12 @@ test_renderSpec = TestGroup "Render"
         "Contains unrecognized timezone abbreviation: WETS"
         (Just "_Maybe you meant: WET, WEST_")
         Nothing
+      ]
+    , testCase "Known timezone abbreviation" $
+      mkChatCase arbitraryTime1 "10am MSK" userMoscow userHavana
+      [ translWithoutNotes
+          "\"10am MSK\", 30 January 2023, Moscow Time (UTC+03:00) "
+          "02:00, Monday, 30 January 2023 in America/Havana"
       ]
     ]
   , TestGroup "Modal"


### PR DESCRIPTION
## Description

Problem: Timezone abbreviations can be ambiguous, so we need to provide
comprehensive information about inferred timezone abbreviation in order
to prevent users confusion.

Solution: For timezone abbreviations, ephemerals explicitly state
timezone abbreviation info.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #71 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
