### PR TITLE
[#79] Add support for hyphenated intervals

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,8 +32,6 @@ steps:
 
   - label: xrefcheck
     command: nix run github:serokell/xrefcheck
-    soft_fail:
-      - exit_status: 1
 
   - label: REUSE lint
     command: nix build -L .#checks.x86_64-linux.reuse-lint

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ stack-hie.yaml*
 .vscode/
 result
 *.txt
+stack-hie.yaml
+stack-hie.yaml.lock
+feedback.log

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ run:
 	$(MAKEU) PACKAGE=tzbot-exe run
 
 stylish:
-	find . -name '.stack-work' -prune -o -name '.dist-newstyle' -prune -o -name '*.hs' -exec stylish-haskell -i '{}' \;
+	find . -name '.stack-work' -prune -o -name 'dist-newstyle' -prune -o -name '*.hs' -exec stylish-haskell -i '{}' \;
 
 lint:
 	hlint .

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 # tzbot
 
-| This project is participating in [ZuriHac 2022](https://zfoh.ch/zurihac2022/projects.html)! Join the [discord server](https://discord.gg/G49DeVY) for communications. |
-| --- |
-
 `tzbot` is a Slack bot that detects messages with references to some point in time,
 and converts them to your timezone.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -88,5 +88,5 @@ do not require setting up a Slack workspace. They can be worked on in isolation.
       "Open channel details" > "Integrations" > "Add apps" > "tzbot"
 1. Run the bot with `make run` (or `cabal run tzbot-exe` / `stack run`).
 
- [time-zones-offsets]: https://spin.atomicobject.com/2016/07/06/time-zones-offsets
+ [time-zones-offsets]: https://spin.atomicobject.com/2016/07/06/time-zones-offsets/
  [tzlabel]: https://hackage.haskell.org/package/tz-0.1.3.6/docs/Data-Time-Zones-All.html#t:TZLabel

--- a/package.yaml
+++ b/package.yaml
@@ -110,6 +110,7 @@ tests:
     - tasty-hspec
     - tasty-hunit
     - tasty-quickcheck
+    - text
     - time
     - tztime
     - QuickCheck

--- a/src/TzBot/Parser.hs
+++ b/src/TzBot/Parser.hs
@@ -9,6 +9,7 @@ module TzBot.Parser
 import Universum hiding (many, toList, try)
 
 import Data.Char (isUpper)
+import Data.List qualified as L
 import Data.Map qualified as M
 import Data.String.Conversions (cs)
 import Data.Text qualified as T
@@ -18,6 +19,7 @@ import Data.Time.Calendar.Compat (DayOfMonth, MonthOfYear, Year)
 import Data.Time.LocalTime (TimeOfDay(..))
 import Data.Time.Zones.All (TZLabel, tzNameLabelMap)
 import Glider.NLP.Tokenizer (Token(..), tokenize)
+import Text.Interpolation.Nyan (int, rmode')
 import Text.Megaparsec hiding (Token)
 
 import TzBot.Instances ()
@@ -212,17 +214,45 @@ type TzParser = Parsec Void [Token]
 >>> parseTimeRefs "7:30pm 2022/08/3"
 [TimeReference {trText = "7:30pm 2022/08/3", trTimeOfDay = 19:30:00, trDateRef = Just (DayOfMonthRef 3 (Just (8,Just 2022))), trLocationRef = Nothing}]
 
->>> parseTimeRefs "2022.8.03 7:30 pm "
+>>> parseTimeRefs "2022.8.03 7:30 pm  "
 [TimeReference {trText = "2022.8.03 7:30 pm", trTimeOfDay = 19:30:00, trDateRef = Just (DayOfMonthRef 3 (Just (8,Just 2022))), trLocationRef = Nothing}]
 
 >>> parseTimeRefs "7:30pm 2022.8.03 America/Havana"
 [TimeReference {trText = "7:30pm 2022.8.03 America/Havana", trTimeOfDay = 19:30:00, trDateRef = Just (DayOfMonthRef 3 (Just (8,Just 2022))), trLocationRef = Just (TimeZoneRef America__Havana)}]
 
+>>> parseTimeRefs "tomorrow 10am -11 am"
+[TimeReference {trText = "tomorrow 10am", trTimeOfDay = 10:00:00, trDateRef = Just (DaysFromToday 1), trLocationRef = Nothing},TimeReference {trText = "tomorrow 11 am", trTimeOfDay = 11:00:00, trDateRef = Just (DaysFromToday 1), trLocationRef = Nothing}]
+
+>>> parseTimeRefs "tomorrow 10am /  11 am"
+[TimeReference {trText = "tomorrow 10am", trTimeOfDay = 10:00:00, trDateRef = Just (DaysFromToday 1), trLocationRef = Nothing},TimeReference {trText = "tomorrow 11 am", trTimeOfDay = 11:00:00, trDateRef = Just (DaysFromToday 1), trLocationRef = Nothing}]
+
+>>> parseTimeRefs "between 10am and 11:30am UTC"
+[TimeReference {trText = "10am UTC", trTimeOfDay = 10:00:00, trDateRef = Nothing, trLocationRef = Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"}))},TimeReference {trText = "11:30am UTC", trTimeOfDay = 11:30:00, trDateRef = Nothing, trLocationRef = Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"}))}]
+
+>>> parseTimeRefs "Let's go on Wednesday at 10:00 or 11:00."
+[TimeReference {trText = "on Wednesday at 10:00", trTimeOfDay = 10:00:00, trDateRef = Just (DayOfWeekRef Wednesday), trLocationRef = Nothing},TimeReference {trText = "on Wednesday 11:00", trTimeOfDay = 11:00:00, trDateRef = Just (DayOfWeekRef Wednesday), trLocationRef = Nothing}]
+
+>>> parseTimeRefs "10-11pm tomorrow works for me"
+[TimeReference {trText = "10pm tomorrow", trTimeOfDay = 22:00:00, trDateRef = Just (DaysFromToday 1), trLocationRef = Nothing},TimeReference {trText = "11pm tomorrow", trTimeOfDay = 23:00:00, trDateRef = Just (DaysFromToday 1), trLocationRef = Nothing}]
+
+>>> parseTimeRefs "How about 10:00 or 11:00 pm tomorrow?"
+[TimeReference {trText = "10:00 pm tomorrow", trTimeOfDay = 22:00:00, trDateRef = Just (DaysFromToday 1), trLocationRef = Nothing},TimeReference {trText = "11:00 pm tomorrow", trTimeOfDay = 23:00:00, trDateRef = Just (DaysFromToday 1), trLocationRef = Nothing}]
+
+>>> parseTimeRefs "7.30-8.30pm"
+[TimeReference {trText = "7.30pm", trTimeOfDay = 19:30:00, trDateRef = Nothing, trLocationRef = Nothing},TimeReference {trText = "8.30pm", trTimeOfDay = 20:30:00, trDateRef = Nothing, trLocationRef = Nothing}]
+
+>>> parseTimeRefs "7.30am-8.30pm tomorrow"
+[TimeReference {trText = "7.30am tomorrow", trTimeOfDay = 07:30:00, trDateRef = Just (DaysFromToday 1), trLocationRef = Nothing},TimeReference {trText = "8.30pm tomorrow", trTimeOfDay = 20:30:00, trDateRef = Just (DaysFromToday 1), trLocationRef = Nothing}]
+
+>>> parseTimeRefs "7.30-8.30"
+[]
+
 -}
 parseTimeRefs :: Text -> [TimeReference]
 parseTimeRefs =
   -- TODO use better error handling
-  fromMaybe []
+  map matchedToPlain
+    . fromMaybe []
     . parseMaybe timeRefsParser
     -- time reference can be either at the beginning or after a space
     . (Whitespace :)
@@ -231,61 +261,120 @@ parseTimeRefs =
 -- | Parser for multiple 'TimeReference' s.
 --
 -- This looks for all of them in the input and ignores everything surrounding.
-timeRefsParser :: TzParser [TimeReference]
+timeRefsParser :: TzParser [TimeReferenceMatched]
 timeRefsParser = choice'
   [ do
-      tr <- try timeRefParser
+      tr <- try timeRefConjugParser
       trs <- timeRefsParser
-      return $ tr : trs
+      return $ tr <> trs
   , anySingle >> timeRefsParser
   , takeRest >> pure []
   ]
 
--- | Parses a single 'TimeReference', consuming all input.
-timeRefParser :: TzParser TimeReference
+-- | Parses entries like @between 10am and 11am@ or
+-- @10am-11am on thursday or 1pm-2pm on wednesday@
+timeRefConjugParser :: TzParser [TimeReferenceMatched]
+timeRefConjugParser = do
+  firstConjugComponent <- timeRefParser
+  let conjugParser conjWord = do
+        optional' space
+        _ <- word' conjWord
+        -- no space here before `timeRefParser` requires a space before the contents
+        secondConjugComponent <- timeRefParser
+        pure $ unifyConjugComponents $ firstConjugComponent <> secondConjugComponent
+
+      unifyConjugComponents :: [TimeReferenceMatched] -> [TimeReferenceMatched]
+      unifyConjugComponents lst = do
+        let getUnique :: Eq a => (TimeReferenceMatched -> Maybe a) -> Maybe a
+            getUnique getter = do
+              let many = L.nub $ mapMaybe getter lst
+              case many of
+                [item] -> Just item
+                _ -> Nothing
+        let locRef = getUnique trmLocationRef
+            dateRef = getUnique trmDateRef
+        -- TODO: use lenses
+        flip map lst $
+          (whenJustFunc locRef \l tr -> addLocationIfMissing l tr)
+            . whenJustFunc dateRef \d tr -> addDateIfMissing d tr
+
+  choice'
+    -- note that and/or can be parsed either as conjugations or as "hyphens",
+    -- in the second case am/pm context is also shared
+    [ conjugParser "and"
+    , conjugParser "or"
+    , pure firstConjugComponent
+    ]
+
+addLocationIfMissing
+  :: Matched LocationReference
+  -> TimeReferenceMatched
+  -> TimeReferenceMatched
+addLocationIfMissing l tr =
+  if isNothing (trmLocationRef tr)
+  then tr { trmLocationRef = Just l, trmText = [int||#{trmText tr} (#{mtText l})|] }
+  else tr
+
+addDateIfMissing
+  :: Matched DateReference
+  -> TimeReferenceMatched
+  -> TimeReferenceMatched
+addDateIfMissing d tr =
+  if isNothing (trmDateRef tr)
+  then tr { trmDateRef = Just d, trmText = [int||#{trmText tr} (#{mtText d})|] }
+  else tr
+
+-- | Parses coupled 'TimeReference's, collecting the source text.
+timeRefParser :: TzParser [TimeReferenceMatched]
 timeRefParser = do
   _ <- space
-  (newTrText, timeReference) <- match timeRefParser'
-  return timeReference { trText = concatTokens newTrText }
-
--- | Parses a single 'TimeReference', but does not collect the source text.
-timeRefParser' :: TzParser TimeReference
-timeRefParser' = do
-  let trText = ""
-  precBuilder <- fromMaybe builderInit <$> do
+  (precText, precBuilder) <- match $ fromMaybe builderInit <$> do
     res <- optional' (builderParser False builderInit)
     optional' spacedComma
     pure res
-  trTimeOfDay <- timeOfDayParser
-  builder <- fromMaybe builderInit <$> optional' (builderParser True precBuilder)
-  let trLocationRef = trbLocRef builder
-      trDateRef = trbDateRef builder
-  pure TimeReference {..}
+  timeEntry <- timeEntryParser
+  (afterText, builder) <- match $ fromMaybe builderInit <$> optional' (builderParser True precBuilder)
+  let trmLocationRef = trbLocRef builder
+      trmDateRef = trbDateRef builder
+  let mkTrText refText =
+        T.concat [concatTokens precText, refText, concatTokens afterText]
+  let mkTimeReference todWithText = TimeReferenceMatched
+        { trmText = mkTrText $ mtText todWithText
+        , trmTimeOfDay = mtValue todWithText
+        , trmDateRef
+        , trmLocationRef
+        }
+  pure $ map mkTimeReference case timeEntry of
+    TESingle todwt -> [todwt]
+    TEPair todwt todwt' -> [todwt, todwt']
 
 ----------------------------------------------------------------------------
 ---- Collecting of optional time contexts
 ----------------------------------------------------------------------------
 data ContextBuilder = ContextBuilder
-  { trbDateRef :: Maybe DateReference
-  , trbLocRef  :: Maybe LocationReference
+  { trbDateRef :: Maybe (Matched DateReference)
+  , trbLocRef  :: Maybe (Matched LocationReference)
   } deriving stock (Show, Eq)
 
 builderInit :: ContextBuilder
 builderInit = ContextBuilder Nothing Nothing
 
 data SumContextBuilder
-  = SCBDate DateReference
-  | SCBLocRef LocationReference
+  = SCBDate (Matched DateReference)
+  | SCBLocRef (Matched LocationReference)
 
 sumBuilderParser :: TzParser SumContextBuilder
 sumBuilderParser =
-  choice' [SCBDate <$> dateRefParser, SCBLocRef <$> locRefParser]
+  choice'
+    [ SCBDate . matched <$> match dateRefParser
+    , SCBLocRef . matched <$> match locRefParser
+    ]
 
 builderParser :: Bool -> ContextBuilder -> TzParser ContextBuilder
 builderParser allowSpace b = do
   sumB <- optional'
-    (when allowSpace (void $ optional' spacedComma) >> sumBuilderParser)
-  case sumB of
+    (when allowSpace (void $ optional' spacedComma) >> matched <$> match sumBuilderParser)
+  case fmap mtValue sumB of
     Just (SCBDate dr) -> do
       when (isJust $ trbDateRef b) empty
       builderParser True b { trbDateRef = Just dr }
@@ -295,11 +384,64 @@ builderParser allowSpace b = do
     Nothing -> pure b
 
 ----------------------------------------------------------------------------
--- | Parses a 'TimeOfDay'.
---
--- This is permissive in the space, as it allows none to be between the time and
--- the AM/PM.
-timeOfDayParser :: TzParser TimeOfDay
+matched :: ([Token], a) -> Matched a
+matched (ts, val) = Matched (concatTokens ts) val
+
+data TimeEntry
+  = TESingle (Matched TimeOfDay)
+  -- ^ E.g. @10am@
+  | TEPair (Matched TimeOfDay) (Matched TimeOfDay)
+  -- ^ E.g. @10am-11am@
+
+-- | Parses either a single time of day or a pair with shared
+-- date, location and am/pm contexts.
+timeEntryParser :: TzParser TimeEntry
+timeEntryParser = do
+  let todWithTextParser = matched <$> match timeOfDayParser
+  firstRef <- todWithTextParser
+  let delimitedPair :: TzParser a -> TzParser TimeEntry
+      delimitedPair delim = do
+        optional' space
+        delim
+        optional' space
+        secondRef <- todWithTextParser
+        let getIsAm
+              :: Matched (Maybe (TimeOfDay, Maybe $ Matched Bool), Bool -> TimeOfDay)
+              -> Maybe (Matched Bool)
+            getIsAm ref = fst (mtValue ref) >>= snd
+        let isAmOptions = mapMaybe getIsAm [firstRef, secondRef]
+        let applyIsAm
+              :: Matched Bool
+              -> Matched (Maybe (TimeOfDay, Maybe $ Matched Bool), Bool -> TimeOfDay)
+              -> Matched TimeOfDay
+            applyIsAm isAm ref = do
+              let shouldAppend = isNothing $ getIsAm ref
+              whenFunc shouldAppend (modifyText (<> mtText isAm)) $ fmap (($ mtValue isAm) . snd) ref
+            extractDefaultResult :: Matched (Maybe (TimeOfDay, a), b) -> Maybe (Matched TimeOfDay)
+            extractDefaultResult ref = traverse (fmap fst . fst) ref
+        case isAmOptions of
+          [isAm] -> pure $ (TEPair `on` applyIsAm isAm) firstRef secondRef
+          _ -> maybe empty pure $ TEPair <$> extractDefaultResult firstRef <*> extractDefaultResult secondRef
+
+  choice'
+    [ delimitedPair (punct '-')
+    , delimitedPair (punct '/')
+    , delimitedPair (word' "or")
+    , delimitedPair (word' "and")
+    , TESingle <$> traverse (\(mbRes, _) -> maybe empty (pure . fst) mbRes) firstRef
+    ]
+
+-- | Parses a 'TimeOfDay', returning a template for `timeEntryParser`, which can later
+-- provide another am/pm context that we can infer by default.
+timeOfDayParser
+  :: TzParser
+      (Maybe
+        (TimeOfDay -- if parsed correctly, this is a value with the default am/pm context applied
+        , Maybe (Matched Bool) -- if am/pm context parsed, return it here
+        )
+      , Bool -> TimeOfDay -- if it turns out that another am/pm context should be applied,
+                          -- provide construction function for that case
+      )
 timeOfDayParser = do
   _ <- optional' (relationPreposition >> space)
   hour <- hourParser
@@ -328,19 +470,24 @@ timeOfDayParser = do
     , pure (Nothing, True)
     ]
 
-  isAm <- if isAmRequired
-          then isAmParser
-          else fromMaybe True <$> optional' isAmParser
+  let mkTime isAm = do
+        let todSec = 0
+            todHour
+              | isAm = hour
+              -- pm here
+              | hour < 12 = hour + 12
+              -- ignore pm if hour > 12
+              | otherwise = hour
+            todMin = fromMaybe 0 maybeMin
+        TimeOfDay {..}
 
-  let todSec = 0
-      todHour
-        | isAm = hour
-        -- pm here
-        | hour < 12 = hour + 12
-        -- ignore pm if hour > 12
-        | otherwise = hour
-      todMin = fromMaybe 0 maybeMin
-  pure TimeOfDay {..}
+  mbIsAm <- optional' $ matched <$> match isAmParser
+  pure . (,mkTime) $ case mbIsAm of
+    Just isAm -> Just (mkTime $ mtValue isAm, Just isAm)
+    Nothing ->
+      if isAmRequired
+      then Nothing
+      else Just (mkTime True, Nothing)
 
 isAmParser :: TzParser Bool
 isAmParser = optional' space >>
@@ -517,8 +664,7 @@ isPossibleTimezoneAbbrev w =
   T.all isUpper w
     && T.length w >= 2
     && T.length w <= 5
-    && w /= "AM"
-    && w /= "PM"
+    && not (w `elem` ["AM", "PM", "OR", "AND"])
 
 --------------------------------------------------------------------------------
 -- Storages

--- a/src/TzBot/ProcessEvents/Message.hs
+++ b/src/TzBot/ProcessEvents/Message.hs
@@ -25,7 +25,7 @@ import TzBot.Slack
 import TzBot.Slack.API
 import TzBot.Slack.Events
 import TzBot.Slack.Fixtures qualified as Fixtures
-import TzBot.TimeReference (TimeReference(..))
+import TzBot.TimeReference (TimeReference)
 import TzBot.Util (whenT, withMaybe)
 
 data MessageEventType = METMessage | METMessageEdited

--- a/src/TzBot/Render.hs
+++ b/src/TzBot/Render.hs
@@ -50,8 +50,8 @@ import Text.Interpolation.Nyan (int, rmode')
 import TzBot.Instances ()
 import TzBot.Slack.API (Mrkdwn(Mrkdwn), User(..))
 import TzBot.Slack.API.Block
-import TzBot.TZ (TimeShift(..), checkForTimeshifts, findLastTimeshift)
 import TzBot.TimeReference
+import TzBot.TZ (TimeShift(..), checkForTimeshifts, findLastTimeshift)
 import TzBot.Util
 
 -- Types

--- a/src/TzBot/TimeReference.hs
+++ b/src/TzBot/TimeReference.hs
@@ -33,18 +33,6 @@ We use this type alias to make this distinction a bit more clear.
 -}
 type TimeReferenceText = Text
 
--- | Datatype for keeping value together with its parsed text (as a sequence of tokens)
-data Matched a = Matched
-  { mtText :: Text
-    -- ^ Consumed text
-  , mtValue :: a
-    -- ^ Parsed value
-  } deriving stock (Show, Eq, Generic, Functor, Foldable, Traversable)
-
--- TODO: use lenses
-modifyText :: (Text -> Text) -> Matched a -> Matched a
-modifyText f Matched {..} = Matched {mtText = f mtText, ..}
-
 -- | A reference to a point in time, e.g. "tuesday at 10am", "3pm CST on July 7th"
 data TimeReference = TimeReference
   { trText :: TimeReferenceText -- ^ The original section of the text from where this `TimeReference` was parsed.
@@ -53,22 +41,6 @@ data TimeReference = TimeReference
   , trLocationRef :: Maybe LocationReference
   }
   deriving stock (Eq, Show)
-
-data TimeReferenceMatched = TimeReferenceMatched
-  { trmText :: TimeReferenceText
-  , trmTimeOfDay :: TimeOfDay
-  , trmDateRef :: Maybe (Matched DateReference)
-  , trmLocationRef :: Maybe (Matched LocationReference)
-  }
-  deriving stock (Eq, Show)
-
-matchedToPlain :: TimeReferenceMatched -> TimeReference
-matchedToPlain TimeReferenceMatched {..} = TimeReference
-  { trDateRef = fmap mtValue trmDateRef
-  , trLocationRef = fmap mtValue trmLocationRef
-  , trText = trmText
-  , trTimeOfDay = trmTimeOfDay
-  }
 
 getTzLabelMaybe :: TZLabel -> TimeReference -> Maybe TZLabel
 getTzLabelMaybe senderTz timeRef = case trLocationRef timeRef of

--- a/src/TzBot/TimeReference.hs
+++ b/src/TzBot/TimeReference.hs
@@ -33,6 +33,18 @@ We use this type alias to make this distinction a bit more clear.
 -}
 type TimeReferenceText = Text
 
+-- | Datatype for keeping value together with its parsed text (as a sequence of tokens)
+data Matched a = Matched
+  { mtText :: Text
+    -- ^ Consumed text
+  , mtValue :: a
+    -- ^ Parsed value
+  } deriving stock (Show, Eq, Generic, Functor, Foldable, Traversable)
+
+-- TODO: use lenses
+modifyText :: (Text -> Text) -> Matched a -> Matched a
+modifyText f Matched {..} = Matched {mtText = f mtText, ..}
+
 -- | A reference to a point in time, e.g. "tuesday at 10am", "3pm CST on July 7th"
 data TimeReference = TimeReference
   { trText :: TimeReferenceText -- ^ The original section of the text from where this `TimeReference` was parsed.
@@ -41,6 +53,22 @@ data TimeReference = TimeReference
   , trLocationRef :: Maybe LocationReference
   }
   deriving stock (Eq, Show)
+
+data TimeReferenceMatched = TimeReferenceMatched
+  { trmText :: TimeReferenceText
+  , trmTimeOfDay :: TimeOfDay
+  , trmDateRef :: Maybe (Matched DateReference)
+  , trmLocationRef :: Maybe (Matched LocationReference)
+  }
+  deriving stock (Eq, Show)
+
+matchedToPlain :: TimeReferenceMatched -> TimeReference
+matchedToPlain TimeReferenceMatched {..} = TimeReference
+  { trDateRef = fmap mtValue trmDateRef
+  , trLocationRef = fmap mtValue trmLocationRef
+  , trText = trmText
+  , trTimeOfDay = trmTimeOfDay
+  }
 
 getTzLabelMaybe :: TZLabel -> TimeReference -> Maybe TZLabel
 getTzLabelMaybe senderTz timeRef = case trLocationRef timeRef of

--- a/src/TzBot/Util.hs
+++ b/src/TzBot/Util.hs
@@ -213,3 +213,10 @@ secondsPerMinute = 60
 
 tztimeOffset :: TZTime -> Offset
 tztimeOffset = Offset . timeZoneMinutes . tzTimeOffset
+
+whenJustFunc :: Maybe b -> (b -> a -> a) -> a -> a
+whenJustFunc Nothing _f = id
+whenJustFunc (Just b) f = f b
+
+whenFunc :: Bool -> (a -> a) -> a -> a
+whenFunc b f = if b then f else id

--- a/test/Test/TzBot/GetTimeshiftsSpec.hs
+++ b/test/Test/TzBot/GetTimeshiftsSpec.hs
@@ -19,8 +19,8 @@ import Test.Tasty.HUnit (Assertion, assertFailure, testCase, (@?=))
 import Text.Interpolation.Nyan
 
 import TzBot.Parser (parseTimeRefs)
-import TzBot.TZ (TimeShift(..), checkForTimeshifts, checkForTimeshifts')
 import TzBot.TimeReference (TimeReferenceToUTCResult(..), timeReferenceToUTC)
+import TzBot.TZ (TimeShift(..), checkForTimeshifts, checkForTimeshifts')
 import TzBot.Util
 
 springHavana2022utc, autumnHavana2022utc, springHavana2023utc :: UTCTime

--- a/test/Test/TzBot/ParserSpec.hs
+++ b/test/Test/TzBot/ParserSpec.hs
@@ -1,0 +1,153 @@
+-- SPDX-FileCopyrightText: 2022 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module Test.TzBot.ParserSpec
+  ( test_parserSpec
+  ) where
+
+import Universum
+
+import Data.Text qualified as T
+import Data.Time (DayOfWeek(..), TimeOfDay(..), defaultTimeLocale, formatTime)
+import Test.Tasty
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
+import Test.Tasty.Runners (TestTree(TestGroup))
+import Text.Interpolation.Nyan (int, rmode', rmode's)
+
+import TzBot.Parser (parseTimeRefs)
+import TzBot.TimeReference
+  (DateReference(..), LocationReference(..), TimeReference(..), TimeZoneAbbreviationInfo(..))
+
+{- | This test suite contains only tests whose output is too big
+ - to be placed in doctests
+ -}
+test_parserSpec :: TestTree
+test_parserSpec = TestGroup "ParserBig"
+  [ testCase "First slashed term contains all references, second slashed term contains no refs" $
+    mkTestCase
+      "How about Wednesday at 10:00 / 11:00 UTC or 14:00 / 15:00"
+      [ TimeReference
+          "Wednesday at 10:00 UTC"
+          (TimeOfDay 10 00 00)
+          (Just (DayOfWeekRef Wednesday))
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      , TimeReference
+          "Wednesday 11:00 UTC"
+          (TimeOfDay 11 00 00)
+          (Just (DayOfWeekRef Wednesday))
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      , TimeReference
+          "14:00 (Wednesday) (UTC)"
+          (TimeOfDay 14 00 00)
+          (Just (DayOfWeekRef Wednesday))
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      , TimeReference
+          "15:00 (Wednesday) (UTC)"
+          (TimeOfDay 15 00 00)
+          (Just (DayOfWeekRef Wednesday))
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      ]
+  , testCase "First slashed term has day of week, second has also UTC" $
+    mkTestCase
+      "How about Wednesday at 10:00 / 11:00 OR 14:00 / 15:00 at Thursday UTC"
+      [ TimeReference
+          "Wednesday at 10:00 (UTC)"
+          (TimeOfDay 10 00 00)
+          (Just (DayOfWeekRef Wednesday))
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      , TimeReference
+          "Wednesday 11:00 (UTC)"
+          (TimeOfDay 11 00 00)
+          (Just (DayOfWeekRef Wednesday))
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      , TimeReference
+          "14:00 at Thursday UTC"
+          (TimeOfDay 14 00 00)
+          (Just (DayOfWeekRef Thursday))
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      , TimeReference
+          "15:00 at Thursday UTC"
+          (TimeOfDay 15 00 00)
+          (Just (DayOfWeekRef Thursday))
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      ]
+  , testCase "Some hyphenated intervals" $
+    mkTestCase
+      "Hi guys! Let’s have a sync call tomorrow? Almost every time from 7am-2pm UTC works (except 10:30am - 12pm UTC)"
+      [ TimeReference
+          "7am UTC"
+          (TimeOfDay 07 00 00)
+          (Nothing)
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      , TimeReference
+          "2pm UTC"
+          (TimeOfDay 14 00 00)
+          (Nothing)
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      , TimeReference
+          "10:30am UTC"
+          (TimeOfDay 10 30 00)
+          (Nothing)
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      , TimeReference
+          "12pm UTC"
+          (TimeOfDay 12 00 00)
+          (Nothing)
+          (Just (TimeZoneAbbreviationRef (TimeZoneAbbreviationInfo {tzaiAbbreviation = "UTC", tzaiOffsetMinutes = 0, tzaiFullName = "UTC"})))
+      ]
+  ]
+
+mkTestCase :: HasCallStack => Text -> [TimeReference] -> Assertion
+mkTestCase input expectedRefs = do
+  let outputRefs = parseTimeRefs input
+  assertRefPairs expectedRefs outputRefs
+
+assertRefPairs :: HasCallStack => [TimeReference] -> [TimeReference] -> Assertion
+assertRefPairs [] [] = pass
+assertRefPairs [] os =
+  assertFailure
+    [int||
+      Expected no more time references, but got
+      #{prettyPrintList os}
+      |]
+assertRefPairs es [] =
+  assertFailure
+    [int||
+      Expected more time references #{prettyPrintList es}
+      |]
+assertRefPairs (e : es) (o : os) =
+  assertRefPair e o >> assertRefPairs es os
+
+prettyPrintTimeReference :: Char -> TimeReference -> Text
+prettyPrintTimeReference start TimeReference {..} =
+  [int|s|
+  #{start} TimeReference
+      #s{trText}
+      (#{renderTimeOfDay trTimeOfDay})
+      (#s{trDateRef})
+      (#s{trLocationRef})
+    |]
+  where
+  renderTimeOfDay (t :: TimeOfDay) = formatTime defaultTimeLocale "TimeOfDay %H %M %S" t
+
+prettyPrintList :: [TimeReference] -> Text
+prettyPrintList [] = "Empty list"
+prettyPrintList (t : ts) =
+  T.unlines $ prettyPrintTimeReference '[' t
+    : map (prettyPrintTimeReference ',') ts
+    <> ["]"]
+
+assertRefPair :: HasCallStack => TimeReference -> TimeReference -> Assertion
+assertRefPair expTr outTr = do
+  assertUnit "Text" trText
+  assertUnit "Date reference" trDateRef
+  assertUnit "Location reference" trLocationRef
+  assertUnit "Time of day" trTimeOfDay
+  where
+    assertUnit :: (Show a, Eq a) => Text -> (TimeReference -> a) -> Assertion
+    assertUnit note getter = do
+      let expUnit = getter expTr
+          outUnit = getter outTr
+      when (expUnit /= outUnit) $
+        assertFailure [int||#{note}: expected #s{expUnit} but got #s{outUnit}|]

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -301,6 +301,7 @@ test-suite tzbot-test
       Test.TzBot.GetTimeshiftsSpec
       Test.TzBot.HandleTooManyRequests
       Test.TzBot.MessageBlocksSpec
+      Test.TzBot.ParserSpec
       Test.TzBot.RenderSpec
       Test.TzBot.TimeReferenceToUtcSpec
       Tree
@@ -376,6 +377,7 @@ test-suite tzbot-test
     , tasty-hspec
     , tasty-hunit
     , tasty-quickcheck
+    , text
     , time
     , tzbot
     , tztime


### PR DESCRIPTION
## Description

Problem: If a user writes "I'll be available around 10am-11am UTC", 10am has no location reference.

Solution: Add support for simple hyphenated and slashed intervals sharing all other context, resulting two different time references that are processed separately further. Also added conjugations via "and" and "or".

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #79, partly fixed #16

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
