### PR TITLE
[#89] Fix parsing of minutes after `h` separator

### DIFF
--- a/src/TzBot/Parser.hs
+++ b/src/TzBot/Parser.hs
@@ -719,7 +719,11 @@ timeOfDayParser = do
                 | h `elem` ['h', 'H'] ->
                     case after of
                       "" -> pure (False, 0)
-                      afterStr -> pure (False, fromMaybe 0 $ readMinutes afterStr)
+                      afterStr ->
+                        -- Try to parse what comes after the `h` separator as a number of minutes
+                        case readMinutes afterStr of
+                          Nothing -> empty
+                          Just mins -> pure (False, mins)
                 | otherwise -> empty
         , do
             -- Try to parse an "." separator and a required "minutes" component

--- a/test/Test/TzBot/ParserSpec.hs
+++ b/test/Test/TzBot/ParserSpec.hs
@@ -5,6 +5,7 @@
 module Test.TzBot.ParserSpec
   ( test_parserSpec
   , test_Two_Time_References
+  , test_Regression_Tests
   ) where
 
 import TzPrelude
@@ -12,7 +13,7 @@ import TzPrelude
 import Data.Text qualified as T
 import Data.Time (DayOfWeek(..), TimeOfDay(..), defaultTimeLocale, formatTime)
 import Test.Tasty
-import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase, (@?=))
 import Test.Tasty.Runners (TestTree(TestGroup))
 import Text.Interpolation.Nyan (int, rmode', rmode's)
 
@@ -206,6 +207,12 @@ test_Two_Time_References =
                 )
             }
         ]
+  ]
+
+test_Regression_Tests :: [TestTree]
+test_Regression_Tests =
+  [ testCase "#89" do
+      parseTimeRefs "7hff" @?= []
   ]
 
 mkTestCase :: HasCallStack => Text -> [TimeReference] -> Assertion


### PR DESCRIPTION
## Description

The parser was accepting `7hff` and then defaulting `ff` to `0 minutes`.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #89

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
