### PR TITLE
[Chore] Avoid `RecordWildCards`

### DIFF
--- a/src/TzBot/Config.hs
+++ b/src/TzBot/Config.hs
@@ -102,16 +102,16 @@ readConfigWithEnv env mbPath =
   -- After this, we catch yaml exception in order to pretty-print it later.
   handle handleFunc $ traverse evaluate $ toEither
     $ do
-  cAppToken <- fetchRequired "appToken" appTokenEnv cAppToken
-  cBotToken <- fetchRequired "botToken" botTokenEnv cBotToken
-  cMaxRetries <- fetchOptional maxRetriesEnv cMaxRetries `bindValidation` validateMaxTries
-  cCacheUsersInfo           <- fetchOptional cacheUsersEnv        cCacheUsersInfo
-  cCacheConversationMembers <- fetchOptional cacheConvMembersEnv  cCacheConversationMembers
-  cFeedbackChannel          <- fetchOptional feedbackChannelEnv   cFeedbackChannel
-  cFeedbackFile             <- fetchOptional feedbackFileEnv      cFeedbackFile
-  cCacheReportDialog        <- fetchOptional cacheReportDialogEnv cCacheReportDialog
-  cInverseHelpUsageChance   <- fetchOptional inverseHelpUsageChanceEnv cInverseHelpUsageChance
-  cLogLevel                 <- fetchOptional logLevelEnv          cLogLevel
+  cAppToken <- fetchRequired "appToken" appTokenEnv _cfg.cAppToken
+  cBotToken <- fetchRequired "botToken" botTokenEnv _cfg.cBotToken
+  cMaxRetries <- fetchOptional maxRetriesEnv _cfg.cMaxRetries `bindValidation` validateMaxTries
+  cCacheUsersInfo           <- fetchOptional cacheUsersEnv             _cfg.cCacheUsersInfo
+  cCacheConversationMembers <- fetchOptional cacheConvMembersEnv       _cfg.cCacheConversationMembers
+  cFeedbackChannel          <- fetchOptional feedbackChannelEnv        _cfg.cFeedbackChannel
+  cFeedbackFile             <- fetchOptional feedbackFileEnv           _cfg.cFeedbackFile
+  cCacheReportDialog        <- fetchOptional cacheReportDialogEnv      _cfg.cCacheReportDialog
+  cInverseHelpUsageChance   <- fetchOptional inverseHelpUsageChanceEnv _cfg.cInverseHelpUsageChance
+  cLogLevel                 <- fetchOptional logLevelEnv               _cfg.cLogLevel
   pure Config {..}
   where
     handleFunc :: Y.ParseException -> IO (Either [LoadConfigError] $ Config 'CSFinal)
@@ -127,7 +127,7 @@ readConfigWithEnv env mbPath =
 
     _cfg :: Config 'CSInterm
     -- The most easy way to read file on demand, acceptable here.
-    _cfg@Config {..} = unsafePerformIO $
+    _cfg = unsafePerformIO $
         loadYamlSettings (maybeToList mbPath) [toJSON defaultConfig] ignoreEnv
 
     fetchRequired

--- a/src/TzBot/Feedback/Dialog/Types.hs
+++ b/src/TzBot/Feedback/Dialog/Types.hs
@@ -23,11 +23,11 @@ newtype ReportDialogId = ReportDialogId { unReportDialogId :: Text }
   deriving newtype (ToJSON, FromJSON, Buildable, Hashable)
 
 data ReportDialogEntry = ReportDialogEntry
-  { rpmMessageText :: Text
-  , rpmTimeConversion :: Maybe ConversionPairs
-  , rpmSenderTimeZone :: TZLabel
-  , rpmMessageTimestamp :: UTCTime
-  , rpmUserId :: UserId
-  , rpmChannelId :: ChannelId
-  , rpmThreadId :: Maybe ThreadId
+  { rpeMessageText :: Text
+  , rpeTimeConversion :: Maybe ConversionPairs
+  , rpeSenderTimeZone :: TZLabel
+  , rpeMessageTimestamp :: UTCTime
+  , rpeUserId :: UserId
+  , rpeChannelId :: ChannelId
+  , rpeThreadId :: Maybe ThreadId
   } deriving stock (Eq, Show, Generic)

--- a/src/TzBot/Feedback/Save.hs
+++ b/src/TzBot/Feedback/Save.hs
@@ -42,9 +42,9 @@ logFeedbackError (displayException -> err) = do
 --   and record to the file if configured.
 saveFeedback :: FeedbackEntry -> BotM ()
 saveFeedback entry = UnliftIO.handleAny logFeedbackError $ do
-  FeedbackConfig {..} <- asks bsFeedbackConfig
-  whenJust fcFeedbackChannel $ saveFeedbackSlack entry
-  whenJust fcFeedbackFile $ saveFeedbackFile entry
+  feedbackConfig <- asks bsFeedbackConfig
+  whenJust feedbackConfig.fcFeedbackChannel $ saveFeedbackSlack entry
+  whenJust feedbackConfig.fcFeedbackFile $ saveFeedbackFile entry
 
 -- Send to the slack channel
 saveFeedbackSlack :: FeedbackEntry -> ChannelId -> BotM ()

--- a/src/TzBot/Parser.hs
+++ b/src/TzBot/Parser.hs
@@ -1165,9 +1165,9 @@ data TimeReferenceMatched = TimeReferenceMatched
   deriving stock (Eq, Show)
 
 matchedToPlain :: TimeReferenceMatched -> TimeReference
-matchedToPlain TimeReferenceMatched {..} = TimeReference
-  { trDateRef = fmap mtValue trmDateRef
-  , trLocationRef = fmap mtValue trmLocationRef
-  , trText = trmText
-  , trTimeOfDay = trmTimeOfDay
+matchedToPlain trm = TimeReference
+  { trDateRef = fmap mtValue trm.trmDateRef
+  , trLocationRef = fmap mtValue trm.trmLocationRef
+  , trText = trm.trmText
+  , trTimeOfDay = trm.trmTimeOfDay
   }

--- a/src/TzBot/ProcessEvents/BlockAction.hs
+++ b/src/TzBot/ProcessEvents/BlockAction.hs
@@ -13,8 +13,7 @@ import Data.Aeson (Value)
 import Text.Interpolation.Nyan (int, rmode')
 
 import TzBot.Feedback.Dialog (lookupDialogEntry)
-import TzBot.Feedback.Dialog.Types
-  (ReportDialogEntry(ReportDialogEntry, rpmMessageText, rpmMessageTimestamp, rpmSenderTimeZone, rpmTimeConversion))
+import TzBot.Feedback.Dialog.Types (ReportDialogEntry(..))
 import TzBot.Logger
 import TzBot.Slack (BotM, updateModal)
 import TzBot.Slack.API (UpdateViewReq(UpdateViewReq))
@@ -32,7 +31,7 @@ processReportButtonToggled val =
   mbMetadata <- lookupDialogEntry metadataEntryId
   case mbMetadata of
     Nothing -> logWarn [int||Dialog id not found: #{metadataEntryId}|]
-    Just _metadata@ReportDialogEntry {..} -> updateModal $
+    Just reportDialogEntry -> updateModal $
       UpdateViewReq
-        (mkReportModal rpmMessageText rpmTimeConversion metadataEntryId)
+        (mkReportModal reportDialogEntry.rpeMessageText reportDialogEntry.rpeTimeConversion metadataEntryId)
         (vId $ vaeView val)

--- a/src/TzBot/ProcessEvents/ChannelEvent.hs
+++ b/src/TzBot/ProcessEvents/ChannelEvent.hs
@@ -15,13 +15,13 @@ import TzBot.RunMonad
 import TzBot.Slack.Events (MemberJoinedChannelEvent(..), MemberLeftChannelEvent(..))
 
 processMemberJoinedChannel :: MemberJoinedChannelEvent -> BotM ()
-processMemberJoinedChannel MemberJoinedChannelEvent {..} = do
-  logInfo [int||user #{mjceUser} joined channel #{mjceChannel}|]
+processMemberJoinedChannel evt = do
+  logInfo [int||user #{mjceUser evt} joined channel #{mjceChannel evt}|]
   channelMembersCache <- asks bsConversationMembersCache
-  Cache.update mjceChannel (S.insert mjceUser) channelMembersCache
+  Cache.update evt.mjceChannel (S.insert evt.mjceUser) channelMembersCache
 
 processMemberLeftChannel :: MemberLeftChannelEvent -> BotM ()
-processMemberLeftChannel MemberLeftChannelEvent {..} = do
-  logInfo [int||user #{mlceUser} left channel #{mlceChannel}|]
+processMemberLeftChannel evt = do
+  logInfo [int||user #{mlceUser evt} left channel #{mlceChannel evt}|]
   channelMembersCache <- asks bsConversationMembersCache
-  Cache.update mlceChannel (S.delete mlceUser) channelMembersCache
+  Cache.update evt.mlceChannel (S.delete evt.mlceUser) channelMembersCache

--- a/src/TzBot/ProcessEvents/Command.hs
+++ b/src/TzBot/ProcessEvents/Command.hs
@@ -16,13 +16,13 @@ import TzBot.Slack.API (ChannelId(..), PostEphemeralReq(..), UserId(..))
 import TzBot.Slack.Fixtures qualified as Fixtures
 
 processHelpCommand :: SlashCommand -> BotM ()
-processHelpCommand SlashCommand {..} = do
-  let postEphemeralReq@PostEphemeralReq {..} = PostEphemeralReq
-        { perUser = UserId scUserId
-        , perChannel = ChannelId scChannelId
+processHelpCommand cmd = do
+  let postEphemeralReq = PostEphemeralReq
+        { perUser = UserId cmd.scUserId
+        , perChannel = ChannelId cmd.scChannelId
         , perText = Fixtures.helpMessage
         , perThreadTs = Nothing
         , perBlocks = Nothing
         }
-  logInfo [int||Sending help message to user #{perUser}|]
+  logInfo [int||Sending help message to user #{perUser postEphemeralReq}|]
   sendEphemeralMessage postEphemeralReq

--- a/src/TzBot/ProcessEvents/Common.hs
+++ b/src/TzBot/ProcessEvents/Common.hs
@@ -55,13 +55,13 @@ openModalCommon message channelId whoTriggeredId triggerId mkModalFunc = do
 
   guid <- ReportDialogId <$> liftIO genText
   let metadata = ReportDialogEntry
-        { rpmMessageText = mText message
-        , rpmTimeConversion = conversionPairs
-        , rpmSenderTimeZone = uTz sender
-        , rpmMessageTimestamp = mTs message
-        , rpmUserId = whoTriggeredId
-        , rpmChannelId = channelId
-        , rpmThreadId = mThreadId message
+        { rpeMessageText = mText message
+        , rpeTimeConversion = conversionPairs
+        , rpeSenderTimeZone = uTz sender
+        , rpeMessageTimestamp = mTs message
+        , rpeUserId = whoTriggeredId
+        , rpeChannelId = channelId
+        , rpeThreadId = mThreadId message
         }
   insertDialogEntry guid metadata
   let modal = mkModalFunc msgText conversionPairs guid

--- a/src/TzBot/ProcessEvents/Interactive.hs
+++ b/src/TzBot/ProcessEvents/Interactive.hs
@@ -57,23 +57,23 @@ processViewSubmission (ViewActionEvent view) =
   mbMetadata <- lookupDialogEntry metadataEntryId
   case mbMetadata of
     Nothing -> logWarn [int||Dialog id not found: #{metadataEntryId}|]
-    Just _metadata@ReportDialogEntry {..} -> do
+    Just reportDialogEntry -> do
       logInfo [int||
-        Got feedback from user #{rpmUserId}, \
+        Got feedback from user #{rpeUserId reportDialogEntry}, \
         dialogId #{metadataEntryId}
         |]
       let feedbackEntry = FeedbackEntry
-            { feMessageText = rpmMessageText
-            , feTimeConversion = rpmTimeConversion
+            { feMessageText = reportDialogEntry.rpeMessageText
+            , feTimeConversion = reportDialogEntry.rpeTimeConversion
             , feUserReport = userInput
-            , feMessageTimestamp = rpmMessageTimestamp
-            , feSenderTimezone = rpmSenderTimeZone
+            , feMessageTimestamp = reportDialogEntry.rpeMessageTimestamp
+            , feSenderTimezone = reportDialogEntry.rpeSenderTimeZone
             }
       saveFeedback feedbackEntry
       sendEphemeralMessage $ PostEphemeralReq
-        { perUser = rpmUserId
-        , perChannel = rpmChannelId
-        , perThreadTs = rpmThreadId
+        { perUser = reportDialogEntry.rpeUserId
+        , perChannel = reportDialogEntry.rpeChannelId
+        , perThreadTs = reportDialogEntry.rpeThreadId
         , perText = "Thanks for your feedback!"
         , perBlocks = Nothing
         }

--- a/src/TzBot/RunMonad.hs
+++ b/src/TzBot/RunMonad.hs
@@ -66,8 +66,8 @@ instance K.KatipContext BotM where
   getKatipNamespace = view bsLogNamespaceL
 
 runKatipWithBotState :: BotState -> K.KatipContextT m a -> m a
-runKatipWithBotState BotState {..} action =
-  K.runKatipContextT bsLogEnv bsLogContext bsLogNamespace action
+runKatipWithBotState bs action =
+  K.runKatipContextT bs.bsLogEnv bs.bsLogContext bs.bsLogNamespace action
 ----------------------------------------------------------------------------
 -- Exceptions
 ----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Problem: Matching with `RecordWildCards` can be problematic.

1. It makes it harder to see where identifiers come from. E.g.:
    ```
    f x y D{..} = 
      z
    ```
    Where does `z`` come from? Is it a free variable? Or was it put in scope by `D{..}`? It's not clear.

2. It also makes it hard to see _where_ a variable is used in the definition of a function.
    ```
    f x y z = 
      < huge function definition >
    ```

    If I want to know where and how `x` is used, I can just click it and my IDE will highlight all the places where `x` is used.

    With `D{..}`, no such luck. I usually have to delete `D{..}` and then HLS will point me to where all the fields names no longer typecheck.

Solution: Replace usages of `RecordWildCards` with the recently introduced `OverloadedRecordDot` or `NamedFieldPuns`.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

None

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
