### PR TITLE
[#93] Handle edited events when old message is not in cache

### DIFF
--- a/docs/implementation_details.md
+++ b/docs/implementation_details.md
@@ -9,7 +9,7 @@
 The bot's main function is to capture time references in a message and convert them
 to the receiver's time zone. This can be triggered by some events:
   * A new message was posted in a channel where the bot is present;
-  * A message that has been previously converted was recently edited and it now contains some new time references;
+  * A message has been edited and it now contains some new time references;
   * The user triggered an entrypoint from the message's context menu `⋮`;
   * The user DMed the bot.
 


### PR DESCRIPTION
## Description

Problem: At the moment, when we receive a "message edited" event, and if the old message is not in our cache or it did not contain time references, we ignore the event:

```
-- if not found or expired, just ignore this message 
-- it's too old or just didn't contain any time refs
```

However, it's important to handle these events even when a message is not in the cache. For example:

1. A user types "let's meet at 7" and then amends "7" to "7am". The old message did not contain time refs, but the new one does, so we should handle that.
2. The server is restarted, we'll lose our cache. When the server is back up, we should still react when messages that were sent before the restart are edited.

Solution: If the old message's time refs are not found in the cache, inspect the `previous_message` field from the event JSON, and parse its time refs again.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #93

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
