### PR TITLE
[#107] Correctly parse `channel_join` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and converts them to your timezone.
 
   If a word _looks_ like a timezone abbreviation but is not known by the bot, the user is given
   a hint of what abbreviations the sender probably meant.
-* [ ] Multiple time references with shared context are processed correctly. For example,
+* [x] Multiple time references with shared context are processed correctly. For example,
       "Let's meet between 10 and 11pm tomorrow" contains two references: "10(pm) (tomorrow)" and "11pm tomorrow".
 
 ## Contributing

--- a/src/TzBot/Cache.hs
+++ b/src/TzBot/Cache.hs
@@ -152,7 +152,7 @@ lookup
   -> m (Maybe v)
 lookup key cache = liftIO $ Cache.lookup cache.tcCache key
 
--- | Update the value by the key, expiration is not taken into account.
+-- | Update the value by the key (if the key exists in the cache), expiration is not taken into account.
 update
   :: forall k v m. (Hashable k, MonadIO m)
   => k

--- a/src/TzBot/ProcessEvents/Common.hs
+++ b/src/TzBot/ProcessEvents/Common.hs
@@ -76,9 +76,12 @@ getTimeReferencesFromMessage message =
   concatMap parseTimeRefs <$> getTextPiecesFromMessage message
 
 -- | Extract separate text pieces from the Slack message that can contain
--- the whole time reference. The main way is analyzing the message's block
--- structure, but since it's not documented it can not work sometimes,
--- `ignoreCodeBlocksManually` is used a reserve function.
+-- the whole time reference.
+--
+-- This analyses the message's block structure.
+-- The blocks API is not fully documented, so there's a chance our block parser
+-- may fail.
+-- When that happens, we use `ignoreCodeBlocksManually` as a fallback.
 getTextPiecesFromMessage
   :: (KatipContext m)
   => Message
@@ -107,9 +110,11 @@ getTextPiecesFromMessage message = do
         logWarn [int||Unknown level2 block types: #{listF $ map ubeType l2Errs}|]
       pure pieces
 
-{- | Simple function that works in a very naive way, but it's just reserve
- - option when Slack blocks can't be parsed.
- -}
+{- | Analyses a string, naively looks for code blocks wrapped in single or triple backticks
+and ignores them.
+
+All text before/after/between code blocks will be returned.
+-}
 ignoreCodeBlocksManually :: Text -> [Text]
 ignoreCodeBlocksManually txt =
   concatMap (splitByCodeBlocks simpleCodeDelimiter) $

--- a/src/TzBot/Slack/API.hs
+++ b/src/TzBot/Slack/API.hs
@@ -225,7 +225,7 @@ data Message = Message
   , mThreadId :: Maybe ThreadId
   , mEdited :: Bool
   , mSubType :: Maybe Text
-  , msgBlocks :: WithUnknown [MessageBlock]
+  , msgBlocks :: Maybe (WithUnknown [MessageBlock])
   } deriving stock (Eq, Show, Generic)
 
 instance FromJSON Message where
@@ -241,7 +241,7 @@ parseMessage o = do
   mSubType <- o .:? "subtype"
   mEdited <- fmap (isJust @Text) . runMaybeT $
     MaybeT (o .:? "edited") >>= MaybeT . (.:? "ts")
-  msgBlocks <- o .: "blocks"
+  msgBlocks <- o .:? "blocks"
   pure Message {..}
 
 -- | See: https://api.slack.com/types/user

--- a/src/TzBot/Util.hs
+++ b/src/TzBot/Util.hs
@@ -154,6 +154,10 @@ neConcatMap func ns = foldr1 (<>) $ fmap func ns
 stripPrefixIfPresent :: Eq a => [a] -> [a] -> [a]
 stripPrefixIfPresent pref x = fromMaybe x $ stripPrefix pref x
 
+-- | The `FromJSON` instance will try to deserialize the json
+-- to a value of type @a@.
+--
+-- If it's not possible, the json document will be stored as-is in a `Left` constructor.
 newtype WithUnknown a = WithUnknown { unUnknown :: Either Value a }
   deriving stock (Show, Eq)
 

--- a/test/Test/TzBot/Slack/API/Parser.hs
+++ b/test/Test/TzBot/Slack/API/Parser.hs
@@ -1,0 +1,56 @@
+-- SPDX-FileCopyrightText: 2023 Serokell <https://serokell.io/>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+module Test.TzBot.Slack.API.Parser
+  ( unit_Parse_message_channel_join_events
+  ) where
+
+import TzPrelude
+
+import Data.Aeson
+import Data.Aeson.QQ.Simple (aesonQQ)
+import Data.Aeson.Types (parseEither)
+
+import Test.Tasty.HUnit
+import Text.Read (read)
+import TzBot.Slack.API
+import TzBot.Slack.Events
+
+-- https://github.com/serokell/tzbot/issues/107
+unit_Parse_message_channel_join_events :: Assertion
+unit_Parse_message_channel_join_events = do
+  parseEither @_ @MessageEvent parseJSON [aesonQQ|
+    {
+        "channel": "CKL24PSG4",
+        "channel_type": "channel",
+        "event_ts": "1693995287.039729",
+        "inviter": "UCEDSC6AK",
+        "subtype": "channel_join",
+        "text": "<@U04NKKJ4JEN> has joined the channel",
+        "ts": "1693995287.039729",
+        "type": "message",
+        "user": "U04NKKJ4JEN"
+    }
+  |] @?=
+    Right
+      ( MessageEvent
+        { meChannel = ChannelId
+            { unChannelId = "CKL24PSG4" }
+        , meChannelType = Just CTChannel
+        , meMessage = Message
+            { mUser = UserId
+                { unUserId = "U04NKKJ4JEN" }
+            , mText = "<@U04NKKJ4JEN> has joined the channel"
+            , mMessageId = MessageId
+                { unMessageId = "1693995287.039729" }
+            , mTs = read "2023-09-06 10:14:47.039729 UTC"
+            , mThreadId = Nothing
+            , mEdited = False
+            , mSubType = Just "channel_join"
+            , msgBlocks = Nothing
+            }
+        , meTs = read "2023-09-06 10:14:47.039729 UTC"
+        , meMessageDetails = MDUserJoinedChannel
+        }
+      )

--- a/tzbot.cabal
+++ b/tzbot.cabal
@@ -306,6 +306,7 @@ test-suite tzbot-test
       Test.TzBot.MessageBlocksSpec
       Test.TzBot.ParserSpec
       Test.TzBot.RenderSpec
+      Test.TzBot.Slack.API.Parser
       Test.TzBot.TimeReferenceToUtcSpec
       Tree
       Paths_tzbot


### PR DESCRIPTION
## Description

Problem: The parser fails to parse events of type `message` and subtype
`channel_join`, and the logs are flooded with errors.

This seems to happen because the parser expects every event of type
`message` to have a `blocks` field, and that's not always true.

Solution: Make the `blocks` field optional.

## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #107

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).

## ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/tzbot/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y`
