### PR TITLE
[#109] Enhance `MessageContext`

### DIFF
--- a/src/TzBot/Logger.hs
+++ b/src/TzBot/Logger.hs
@@ -16,7 +16,7 @@ import Data.Aeson (KeyValue((.=)), ToJSON(..), object)
 import Katip
 import Text.Interpolation.Nyan (int, rmode's)
 
-import TzBot.Slack.API (MessageId(..))
+import TzBot.Slack.API (ChannelId(..), MessageId(..))
 
 logSugar_ :: (KatipContext m, HasCallStack) => Severity -> Text -> m ()
 logSugar_ sev = logLocM sev . logStr
@@ -50,7 +50,10 @@ withLogger logLevel action = do
 katipAddNamespaceText :: (KatipContext m) => Text -> m a -> m a
 katipAddNamespaceText txt = katipAddNamespace $ Namespace [txt]
 
--- contexts
+----------------------------------------------------------------------------
+-- Contexts
+----------------------------------------------------------------------------
+
 type EventType = Text
 type EventId = Text
 data EventContext = EventContext EventType EventId
@@ -67,11 +70,16 @@ instance ToObject EventContext
 instance LogItem EventContext where
   payloadKeys _verb _a = AllKeys
 
---
-newtype MessageContext = MessageContext MessageId
+-- | A message is uniquely identified by the Channel ID
+-- and the message timestamp (i.e. `MessageId`).
+data MessageContext = MessageContext ChannelId MessageId
 
 instance ToJSON MessageContext where
-  toJSON (MessageContext msgId) = object ["message_id" .= msgId]
+  toJSON (MessageContext channelId msgId) =
+    object
+      [ "channel_id" .= channelId
+      , "message_id" .= msgId
+      ]
 
 instance ToObject MessageContext
 

--- a/src/TzBot/ProcessEvents/Message.hs
+++ b/src/TzBot/ProcessEvents/Message.hs
@@ -82,14 +82,11 @@ withSenderNotBot evt = do
 processMessageEvent :: MessageEvent -> BotM ()
 processMessageEvent evt =
   katipAddNamespaceText "message" $
-  katipAddContext (MessageContext msgId) $
+  katipAddContext (MessageContext evt.meChannel evt.meMessage.mMessageId) $
   whenJustM (filterMessageTypeWithLog evt) $ \mEventType ->
   whenJustM (withSenderNotBot evt) $ \sender -> do
-    timeRefs <- getTimeReferencesFromMessage msg
+    timeRefs <- getTimeReferencesFromMessage evt.meMessage
     processMessageEvent' evt mEventType sender timeRefs
-  where
-  msg = meMessage evt
-  msgId = mMessageId $ meMessage evt
 
 processMessageEvent'
   :: MessageEvent


### PR DESCRIPTION

## Description

Problem: The `MessageContext` data type adds a `message_id` label to log messages, so we can identify which Slack message the server was processing when the log event occurred.

However, a message ID (or message timestamp, really) is not enough to identify a message. A message is uniquely identified by the `(timestamp, channel_id)` pair.

Solution: Add a `channel_id` label to `MessageContext`.


## Related issue(s)

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->

Fixed #109

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).

## ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/tzbot/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y`
