### PR TITLE
[#111] Improve ephemeral message phrasing

### DIFF
--- a/src/TzBot/Render.hs
+++ b/src/TzBot/Render.hs
@@ -157,7 +157,7 @@ renderOnSuccess (ModalFlag forModal) sender timeRef timeRefSucess user = do
   let userTzLabel = uTz user
       renderedUserTime = do
         let q = renderUserTime userTzLabel timeRefSucess.trsUtcResult
-        [int||#{q} in #{userTzLabel}|] :: Text
+        [int||#{q} in your timezone (#{userTzLabel})|] :: Text
       mbRefTzLabel = getTzLabelMaybe (uTz sender) timeRef
       mbRenderedUserTime = case mbRefTzLabel of
         Nothing -> Just renderedUserTime

--- a/test/Test/TzBot/RenderSpec.hs
+++ b/test/Test/TzBot/RenderSpec.hs
@@ -46,21 +46,21 @@ test_renderSpec = TestGroup "Render"
       mkChatCase arbitraryTime1 "10am" userMoscow userHavana
       [ convertWithoutNotes
           "\"10am\", 30 January 2023 in Europe/Moscow"
-          "02:00, Monday, 30 January 2023 in America/Havana"
+          "02:00, Monday, 30 January 2023 in your timezone (America/Havana)"
       ]
 
     , testCase "Implicit day" $
       mkChatCase arbitraryTime1 "10am in Europe/Helsinki" userMoscow userHavana
       [ convertWithoutNotes
           "\"10am in Europe/Helsinki\", 30 January 2023"
-          "03:00, Monday, 30 January 2023 in America/Havana"
+          "03:00, Monday, 30 January 2023 in your timezone (America/Havana)"
       ]
 
     , testCase "Everything explicit" $
       mkChatCase arbitraryTime1 "10am in Europe/Helsinki 3 Feb" userMoscow userHavana
       [ convertWithoutNotes
           "\"10am in Europe/Helsinki 3 Feb\""
-          "03:00, Friday, 03 February 2023 in America/Havana"
+          "03:00, Friday, 03 February 2023 in your timezone (America/Havana)"
       ]
     , testCase "Same timezone" $
       mkChatCase arbitraryTime1 "10am" userMoscow userMoscow2
@@ -75,25 +75,25 @@ test_renderSpec = TestGroup "Render"
       mkChatCase arbitraryTime1 "10am in Europe/Helsinki" userMoscow userMoscow
       [ convertWithoutNotes
           "\"10am in Europe/Helsinki\", 30 January 2023"
-          "11:00, Monday, 30 January 2023 in Europe/Moscow"
+          "11:00, Monday, 30 January 2023 in your timezone (Europe/Moscow)"
       ]
     , testCase "Implicit timezone & implicit date & explicit weekday" $
       mkChatCase arbitraryTime1 "10am on wednesday" userMoscow userHavana
       [ convertWithoutNotes
           "\"10am on wednesday\", 01 February 2023 in Europe/Moscow"
-          "02:00, Wednesday, 01 February 2023 in America/Havana"
+          "02:00, Wednesday, 01 February 2023 in your timezone (America/Havana)"
       ]
     , testCase "Implicit timezone & implicit date & explicit days from today" $
       mkChatCase arbitraryTime1 "10am in 3 days" userMoscow userHavana
       [ convertWithoutNotes
           "\"10am in 3 days\", 02 February 2023 in Europe/Moscow"
-          "02:00, Thursday, 02 February 2023 in America/Havana"
+          "02:00, Thursday, 02 February 2023 in your timezone (America/Havana)"
       ]
     , testCase "Implicit timezone & explicit day & implicit month" $
       mkChatCase arbitraryTime1 "10am on the 21st" userMoscow userHavana
       [ convertWithoutNotes
           "\"10am on the 21st\", 21 January 2023 in Europe/Moscow"
-          "02:00, Saturday, 21 January 2023 in America/Havana"
+          "02:00, Saturday, 21 January 2023 in your timezone (America/Havana)"
       ]
     , testCase "Unknown timezone abbreviation, no similar known ones" $
       mkChatCase arbitraryTime1 "10am KAMAZ" userMoscow userHavana
@@ -113,7 +113,7 @@ test_renderSpec = TestGroup "Render"
       mkChatCase arbitraryTime1 "10am MSK" userMoscow userHavana
       [ convertWithoutNotes
           "\"10am MSK\", 30 January 2023, Moscow Time (UTC+03:00) "
-          "02:00, Monday, 30 January 2023 in America/Havana"
+          "02:00, Monday, 30 January 2023 in your timezone (America/Havana)"
       ]
     , TestGroup "Overlap"
       [ testCase "Explicit timezone" $
@@ -170,7 +170,7 @@ test_renderSpec = TestGroup "Render"
       mkChatCase nearClockChange "10am" userMoscow userHavana
       [ convertWithCommonNote
           "\"10am\", 11 March 2023 in Europe/Moscow"
-          "02:00, Saturday, 11 March 2023 in America/Havana"
+          "02:00, Saturday, 11 March 2023 in your timezone (America/Havana)"
           [int|s|
             _Warning: We inferred that "10am" refers to 11 March 2023 in Europe/Moscow and converted it to America/Havana, but there is a time change near this date_:
               • _At 00:00, 12 March 2023 in America/Havana, the clocks are turned forward 1 hour(s)_.
@@ -181,7 +181,7 @@ test_renderSpec = TestGroup "Render"
       mkChatCase nearClockChange "10am on sunday" userMoscow userHavana
       [ convertWithCommonNote
           "\"10am on sunday\", 12 March 2023 in Europe/Moscow"
-          "03:00, Sunday, 12 March 2023 in America/Havana"
+          "03:00, Sunday, 12 March 2023 in your timezone (America/Havana)"
           [int|s|
             _Warning: We inferred that "10am on sunday" refers to 12 March 2023 in Europe/Moscow and converted it to America/Havana, but there is a time change near this date_:
               • _At 00:00, 12 March 2023 in America/Havana, the clocks are turned forward 1 hour(s)_.
@@ -192,7 +192,7 @@ test_renderSpec = TestGroup "Render"
       mkChatCase nearClockChange "10am on sunday" userHavana userMoscow
       [ convertWithCommonNote
           "\"10am on sunday\", 12 March 2023 in America/Havana"
-          "17:00, Sunday, 12 March 2023 in Europe/Moscow"
+          "17:00, Sunday, 12 March 2023 in your timezone (Europe/Moscow)"
           [int|s|
             _Warning: We inferred that "10am on sunday" refers to 12 March 2023 in America/Havana and converted it to Europe/Moscow, but there is a time change near this date_:
               • _At 00:00, 12 March 2023 in America/Havana, the clocks are turned forward 1 hour(s)_.
@@ -207,7 +207,7 @@ test_renderSpec = TestGroup "Render"
         (User {uId="lisbon", uIsBot=False, uTz=Europe__Lisbon})
       [ convertWithCommonNote
           "\"10am\", 26 March 2023 in Europe/London"
-          "10:00, Sunday, 26 March 2023 in Europe/Lisbon"
+          "10:00, Sunday, 26 March 2023 in your timezone (Europe/Lisbon)"
           [int|s|
             _Warning: We inferred that "10am" refers to 26 March 2023 in Europe/London and converted it to Europe/Lisbon, but there is a time change near this date_:
               • _At 01:00, 26 March 2023 in Europe/London, the clocks are turned forward 1 hour(s)_.
@@ -224,7 +224,7 @@ test_renderSpec = TestGroup "Render"
           (User {uId="lisbon", uIsBot=False, uTz=Europe__Lisbon})
         [ convertWithoutNotes
           "\"10am tomorrow\", 26 March 2023 in Europe/London"
-          "10:00, Sunday, 26 March 2023 in Europe/Lisbon"
+          "10:00, Sunday, 26 March 2023 in your timezone (Europe/Lisbon)"
         ]
       , testCase "No warning: 2 days ahead" $
         mkChatCase
@@ -234,7 +234,7 @@ test_renderSpec = TestGroup "Render"
           (User {uId="lisbon", uIsBot=False, uTz=Europe__Lisbon})
         [ convertWithoutNotes
           "\"10am 2 days ahead\", 26 March 2023 in Europe/London"
-          "10:00, Sunday, 26 March 2023 in Europe/Lisbon"
+          "10:00, Sunday, 26 March 2023 in your timezone (Europe/Lisbon)"
         ]
       , testCase "No warning: fully specified date" $
         mkChatCase
@@ -244,7 +244,7 @@ test_renderSpec = TestGroup "Render"
           (User {uId="lisbon", uIsBot=False, uTz=Europe__Lisbon})
         [ convertWithoutNotes
           "\"10am 26 march\" in Europe/London"
-          "10:00, Sunday, 26 March 2023 in Europe/Lisbon"
+          "10:00, Sunday, 26 March 2023 in your timezone (Europe/Lisbon)"
         ]
       ]
     ]
@@ -253,16 +253,16 @@ test_renderSpec = TestGroup "Render"
 convertWithoutNotes :: Text -> Text -> ConversionPair
 convertWithoutNotes q w = ConversionPair q w Nothing Nothing
 
-mkModalCase :: UTCTime -> Text -> User -> User -> [ConversionPair] -> Assertion
+mkModalCase :: HasCallStack => UTCTime -> Text -> User -> User -> [ConversionPair] -> Assertion
 mkModalCase = mkTestCase asForModalM
 
-mkChatCase :: UTCTime -> Text -> User -> User -> [ConversionPair] -> Assertion
+mkChatCase :: HasCallStack => UTCTime -> Text -> User -> User -> [ConversionPair] -> Assertion
 mkChatCase = mkTestCase asForMessageM
 
 convertWithCommonNote :: Text -> Text -> Text -> ConversionPair
 convertWithCommonNote q w e = ConversionPair q w (Just e) (Just e)
 
-mkTestCase :: ModalFlag -> UTCTime -> Text -> User -> User -> [ConversionPair] -> Assertion
+mkTestCase :: HasCallStack => ModalFlag -> UTCTime -> Text -> User -> User -> [ConversionPair] -> Assertion
 mkTestCase modalFlag eventTimestamp refText sender otherUser expectedOtherUserConversions = do
   let [timeRef] = parseTimeRefs refText
       ephemeralTemplate =


### PR DESCRIPTION

## Description

Problem: For users in, let's say, Tallinn, the ephemeral message will say `<time> <date> in Europe/Athens`. Technically, Tallinn and Athens are on the same offset, but this message may be confusing for some users.

Solution: Amend the message to instead say `<time> <date> in your timezone (Europe/Athens)`.


## Related issue(s)

Fixed #111

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->


## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).

## ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/tzbot/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y`
