### PR TITLE
[#104] Warn about sharing message with the dev team

### DIFF
--- a/src/TzBot/Slack/Modal.hs
+++ b/src/TzBot/Slack/Modal.hs
@@ -7,6 +7,7 @@ module TzBot.Slack.Modal where
 import TzPrelude
 
 import Data.List (singleton)
+import Text.Interpolation.Nyan
 
 import TzBot.Feedback.Dialog.Types
 import TzBot.Instances ()
@@ -44,12 +45,20 @@ mkReportModal shownMessageText conversionPairsMb metadata =
     , mNotifyOnClose = False
     , mCallbackId = Fixtures.reportModal
     , mPrivateMetadata = unReportDialogId metadata
-    , mBlocks = mkBlocks shownMessageText conversionPairsMb $ BInput reportInput
+    , mBlocks = mkBlocks messageText conversionPairsMb $ BInput reportInput
     }
+  where
+    messageText =
+      [int||
+        *Note*: The contents of this message will be shared with the development team.
+
+
+        #{shownMessageText}
+      |]
 
 reportInput :: Input
 reportInput = Input
-      { iLabel = "Time references processed wrongly/unrecognized?"
+      { iLabel = "Are there any issues with how this message was processed?"
       , iBlockId = Fixtures.reportInputBlockId
       , iElement = PlainTextInput
         { ptiActionId = Fixtures.reportInputElementActionId


### PR DESCRIPTION


## Description

Problem: When the user uses the "report an issue" feature, the message with the time references will be sent to the dev team.

Seeing as this message could contain private information (e.g. it could be in a private channel, or be in a DM, etc), we should warn the user about this.

Solution: Warn the user that their message will be shared with the dev team.

## Related issue(s)

Fixed #104

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->


## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).

## ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/tzbot/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y`
