### PR TITLE
[#112] Do not display "You are in this timezone"

### DIFF
--- a/src/TzBot/ProcessEvents/Common.hs
+++ b/src/TzBot/ProcessEvents/Common.hs
@@ -22,7 +22,8 @@ import TzBot.Feedback.Dialog (insertDialogEntry)
 import TzBot.Feedback.Dialog.Types
 import TzBot.Logger
 import TzBot.Parser (parseTimeRefs)
-import TzBot.Render (ConversionPairs, asForModalM, renderAllConversionPairs, renderTemplate)
+import TzBot.Render
+  (ConversionPairs, ModalOrEphemeral(..), renderAllConversionPairs, renderTemplate)
 import TzBot.Slack (BotM, getUserCached, startModal)
 import TzBot.Slack.API
 import TzBot.Slack.API.MessageBlock
@@ -51,7 +52,7 @@ openModalCommon message channelId whoTriggeredId triggerId mkModalFunc = do
       whoTriggered <- getUserCached whoTriggeredId
       pure $
         renderAllConversionPairs whoTriggered $
-          renderTemplate asForModalM msgTimestamp sender neTimeRefs
+          renderTemplate IsModal msgTimestamp sender neTimeRefs
 
   guid <- ReportDialogId <$> liftIO genText
   let metadata = ReportDialogEntry

--- a/src/TzBot/ProcessEvents/Message.hs
+++ b/src/TzBot/ProcessEvents/Message.hs
@@ -182,7 +182,7 @@ processMessageEvent' evt mEventType sender timeRefs =
 
   handleChannelMessageCommon :: Maybe Text -> NonEmpty TimeReference -> BotM ()
   handleChannelMessageCommon mbPermalink neTimeRefs = do
-    let ephemeralTemplate = renderTemplate asForMessageM now sender neTimeRefs
+    let ephemeralTemplate = renderTemplate IsEphemeral now sender neTimeRefs
 
     let sendActionLocal userInChannelId = do
           userInChannel <- getUserCached userInChannelId
@@ -210,7 +210,7 @@ processMessageEvent' evt mEventType sender timeRefs =
     -- only to them, showing it in the way how other users would see
     -- it if it were sent to the common channel.
       let mbEphemeralMessage = renderAllConversionPairs sender $
-            renderTemplate asForModalM now sender neTimeRefs
+            renderTemplate IsModal now sender neTimeRefs
       whenJust mbEphemeralMessage $ \eph -> do
         logInfo [int||
           Received message from the DM, sending conversion to the author

--- a/src/TzBot/Render.hs
+++ b/src/TzBot/Render.hs
@@ -168,7 +168,7 @@ renderOnSuccess (ModalFlag forModal) sender timeRef timeRefSucess user = do
             let isNotSender = ((/=) `on` uId) sender user
                 shouldShowThisConversion = isNotSender || forModal
             guard shouldShowThisConversion
-            Just "You are in this timezone"
+            Just renderedUserTime
       totalClockChanges = checkForClockChanges timeRef timeRefSucess userTzLabel
       mbClockChangeWarning = do
         guard $ not $ null totalClockChanges

--- a/test/Test/TzBot/RenderSpec.hs
+++ b/test/Test/TzBot/RenderSpec.hs
@@ -254,19 +254,19 @@ convertWithoutNotes :: Text -> Text -> ConversionPair
 convertWithoutNotes q w = ConversionPair q w Nothing Nothing
 
 mkModalCase :: HasCallStack => UTCTime -> Text -> User -> User -> [ConversionPair] -> Assertion
-mkModalCase = mkTestCase asForModalM
+mkModalCase = mkTestCase IsModal
 
 mkChatCase :: HasCallStack => UTCTime -> Text -> User -> User -> [ConversionPair] -> Assertion
-mkChatCase = mkTestCase asForMessageM
+mkChatCase = mkTestCase IsEphemeral
 
 convertWithCommonNote :: Text -> Text -> Text -> ConversionPair
 convertWithCommonNote q w e = ConversionPair q w (Just e) (Just e)
 
-mkTestCase :: HasCallStack => ModalFlag -> UTCTime -> Text -> User -> User -> [ConversionPair] -> Assertion
-mkTestCase modalFlag eventTimestamp refText sender otherUser expectedOtherUserConversions = do
+mkTestCase :: HasCallStack => ModalOrEphemeral -> UTCTime -> Text -> User -> User -> [ConversionPair] -> Assertion
+mkTestCase modalOrEphemeral eventTimestamp refText sender otherUser expectedOtherUserConversions = do
   let [timeRef] = parseTimeRefs refText
       ephemeralTemplate =
-        renderTemplate modalFlag eventTimestamp sender $
+        renderTemplate modalOrEphemeral eventTimestamp sender $
           NE.singleton timeRef
 
       otherUserConversions = renderAllConversionPairs otherUser ephemeralTemplate

--- a/test/Test/TzBot/RenderSpec.hs
+++ b/test/Test/TzBot/RenderSpec.hs
@@ -66,7 +66,7 @@ test_renderSpec = TestGroup "Render"
       mkChatCase arbitraryTime1 "10am" userMoscow userMoscow2
       [ convertWithoutNotes
           "\"10am\", 30 January 2023 in Europe/Moscow"
-          "You are in this timezone"
+          "10:00, Monday, 30 January 2023 in your timezone (Europe/Moscow)"
       ]
     , testCase "Back to author, same timezone" $
       mkChatCase arbitraryTime1 "10am" userMoscow userMoscow
@@ -161,7 +161,7 @@ test_renderSpec = TestGroup "Render"
       mkModalCase arbitraryTime1 "10am" userMoscow userMoscow
       [ convertWithoutNotes
           "\"10am\", 30 January 2023 in Europe/Moscow"
-          "You are in this timezone"
+          "10:00, Monday, 30 January 2023 in your timezone (Europe/Moscow)"
       ]
     ]
 


### PR DESCRIPTION
## Description

Problem: We received some feedback that showing "You are in this timezone" in ephemeral messages isn't very useful.
It would be better to just display the converted time, like we do for all other ephemeral messages, for consitency.

Solution: display the converted time.
## Related issue(s)

Fixed #112

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->


## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).

## ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/tzbot/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y`
