### PR TITLE
Diogo/#119 support link blocks

### DIFF
--- a/src/TzBot/Logger.hs
+++ b/src/TzBot/Logger.hs
@@ -16,7 +16,7 @@ import Data.Aeson (KeyValue((.=)), ToJSON(..), object)
 import Katip
 import Text.Interpolation.Nyan (int, rmode's)
 
-import TzBot.Slack.API (ChannelId(..), MessageId(..))
+import TzBot.Slack.API (ChannelId(..), MessageId(..), ThreadId(..))
 
 logSugar_ :: (KatipContext m, HasCallStack) => Severity -> Text -> m ()
 logSugar_ sev = logLocM sev . logStr
@@ -72,13 +72,16 @@ instance LogItem EventContext where
 
 -- | A message is uniquely identified by the Channel ID
 -- and the message timestamp (i.e. `MessageId`).
-data MessageContext = MessageContext ChannelId MessageId
+--
+-- When a message is in a thread, we also need to know the thread ID.
+data MessageContext = MessageContext ChannelId MessageId (Maybe ThreadId)
 
 instance ToJSON MessageContext where
-  toJSON (MessageContext channelId msgId) =
+  toJSON (MessageContext channelId msgId threadId) =
     object
       [ "channel_id" .= channelId
       , "message_id" .= msgId
+      , "thread_id" .= threadId
       ]
 
 instance ToObject MessageContext

--- a/src/TzBot/ProcessEvents/Message.hs
+++ b/src/TzBot/ProcessEvents/Message.hs
@@ -82,7 +82,7 @@ withSenderNotBot evt = do
 processMessageEvent :: MessageEvent -> BotM ()
 processMessageEvent evt =
   katipAddNamespaceText "message" $
-  katipAddContext (MessageContext evt.meChannel evt.meMessage.mMessageId) $
+  katipAddContext (MessageContext evt.meChannel evt.meMessage.mMessageId evt.meMessage.mThreadId) $
   whenJustM (filterMessageTypeWithLog evt) $ \mEventType ->
   whenJustM (withSenderNotBot evt) $ \sender -> do
     timeRefs <- getTimeReferencesFromMessage evt.meMessage

--- a/src/TzBot/Slack/API.hs
+++ b/src/TzBot/Slack/API.hs
@@ -118,6 +118,7 @@ type API =
     :> ReqBody '[JSON] UpdateViewReq
     :> Post '[JSON] (SlackResponse $ SlackContents "view" Value)
   :<|>
+  -- See https://api.slack.com/methods/chat.getPermalink
   Auth '[JWT] Text
     :> "chat.getPermalink"
     :> RequiredParam "channel" ChannelId

--- a/test/Test/TzBot/MessageBlocksSpec.hs
+++ b/test/Test/TzBot/MessageBlocksSpec.hs
@@ -57,8 +57,7 @@ test_messageBlocksSpec = TestGroup "Message blocks" $
         , " 4.1strike "
         , " 4.1bold "
         , "4.2plain "
-        , " 4.2strike "
-        , "  4.2bold "
+        , " 4.2strike github  4.2bold "
         , "between the lists\n"
         , "5.1plain "
         , " 5.1strike "
@@ -70,7 +69,7 @@ test_messageBlocksSpec = TestGroup "Message blocks" $
         , "end!"
         ]
       getLevel2Errors (snd res) @?=
-        [ "emoji", "link", "user", "broadcast"
+        [ "emoji", "user", "broadcast"
         ]
   ]
 


### PR DESCRIPTION
## Description

Problem: If a user types a message with a link, the link text will be ignored by the `MessageBlock` processor:

For example, in the message below, `extractPieces` will return `["Hey let's meet at ", "tomorrow?"]`.

```
Hey, let's meet at [10:30](link to google calendar here) tomorrow?
```

Solution: Parse blocks of type `link`, and collate the link text with adjacent text-like blocks.

![image](https://github.com/serokell/tzbot/assets/718166/24bb811c-2f5d-4443-ac6e-1c90660c46c8)


## Related issue(s)

Fixed #119

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->


## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).

## ✓ Release Checklist

- [ ] I updated the version number in `package.yaml`.
- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/tzbot/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y`
