### PR TITLE
[#108] Handle messages with link previews

### DIFF
--- a/src/TzBot/ProcessEvents/Message.hs
+++ b/src/TzBot/ProcessEvents/Message.hs
@@ -58,6 +58,9 @@ filterMessageTypeWithLog evt = case meMessageDetails evt of
   MDUserLeftChannel -> do
     logInfo [int||Incoming message subtype=channel_leave, ignoring|]
     pure Nothing
+  MDMessageUrlUnfurl -> do
+    logInfo [int||Incoming message with URL preview, ignoring|]
+    pure Nothing
 
 withSenderNotBot :: MessageEvent -> BotM (Maybe User)
 withSenderNotBot evt = do

--- a/src/TzBot/Slack/API/MessageBlock.hs
+++ b/src/TzBot/Slack/API/MessageBlock.hs
@@ -29,6 +29,7 @@ module TzBot.Slack.API.MessageBlock
   , PlainBlockElementLevel1(..)
   , BlockElementLevel2(..)
   , ElementText(..)
+  , ElementLink(..)
   ) where
 
 import TzPrelude

--- a/src/TzBot/Slack/API/MessageBlock.hs
+++ b/src/TzBot/Slack/API/MessageBlock.hs
@@ -12,7 +12,7 @@
  -}
 module TzBot.Slack.API.MessageBlock
   ( -- * Block datatype
-    MessageBlock
+    MessageBlock(..)
 
     -- * Extract errors (or, more precisely, warnings)
   , ExtractError (..)
@@ -22,6 +22,13 @@ module TzBot.Slack.API.MessageBlock
     -- * Functions
   , extractPieces
   , splitExtractErrors
+
+    -- * Internals
+  , BlockElementLevel1(..)
+  , BlockElementType(..)
+  , PlainBlockElementLevel1(..)
+  , BlockElementLevel2(..)
+  , ElementText(..)
   ) where
 
 import TzPrelude

--- a/test/Test/TzBot/Slack/API/Parser.hs
+++ b/test/Test/TzBot/Slack/API/Parser.hs
@@ -3,7 +3,10 @@
 -- SPDX-License-Identifier: MPL-2.0
 
 module Test.TzBot.Slack.API.Parser
-  ( unit_Parse_message_channel_join_events
+  ( unit_Parse_normal_message
+  , unit_Parse_message_channel_join_events
+  , unit_Parse_message_edited
+  , unit_Parse_message_with_broadcast
   ) where
 
 import TzPrelude
@@ -11,12 +14,98 @@ import TzPrelude
 import Data.Aeson
 import Data.Aeson.QQ.Simple (aesonQQ)
 import Data.Aeson.Types (parseEither)
-
 import Test.Tasty.HUnit
 import Text.Read (read)
-import TzBot.Slack.API
-import TzBot.Slack.Events
 
+import TzBot.Slack.API
+import TzBot.Slack.API.MessageBlock
+import TzBot.Slack.Events
+import TzBot.Util
+
+-- | These events happen when a user sends a message to a channel
+unit_Parse_normal_message :: Assertion
+unit_Parse_normal_message = do
+  parseEither @_ @MessageEvent parseJSON [aesonQQ|
+  {
+      "blocks": [
+          {
+              "block_id": "gcG",
+              "elements": [
+                  {
+                      "elements": [
+                          {
+                              "text": "This is a normal message",
+                              "type": "text"
+                          }
+                      ],
+                      "type": "rich_text_section"
+                  }
+              ],
+              "type": "rich_text"
+          }
+      ],
+      "channel": "C02N85E82LV",
+      "channel_type": "channel",
+      "client_msg_id": "9f4b9529-f19f-4587-9b12-a412fe36d070",
+      "event_ts": "1694191319.871489",
+      "team": "T02NDBHSWSG",
+      "text": "This is a normal message",
+      "ts": "1694191319.871489",
+      "type": "message",
+      "user": "U02N85E78QM"
+  }
+  |] @?=
+    Right
+      ( MessageEvent
+          { meChannel = ChannelId
+              { unChannelId = "C02N85E82LV" }
+          , meChannelType = Just CTChannel
+          , meMessage = Message
+              { mUser = UserId
+                  { unUserId = "U02N85E78QM" }
+              , mText = "This is a normal message"
+              , mMessageId = MessageId
+                  { unMessageId = "1694191319.871489" }
+              , mTs = read "2023-09-08 16:41:59.871489 UTC"
+              , mThreadId = Nothing
+              , mEdited = False
+              , mSubType = Nothing
+              , msgBlocks = Just
+                  ( WithUnknown
+                      { unUnknown = Right
+                          [ MessageBlock
+                              { mbElements =
+                                  [ BEL1Plain
+                                      ( PlainBlockElementLevel1
+                                          { beType = WithUnknown { unUnknown = Right BETRichTextSection }
+                                          , beElements = Just
+                                              [ WithUnknown
+                                                  { unUnknown = Right
+                                                      ( BEL2ElementText
+                                                          ( ElementText
+                                                              { etText = "This is a normal message"
+                                                              , etStyle = Nothing
+                                                              }
+                                                          )
+                                                      )
+                                                  }
+                                              ]
+                                          }
+                                      )
+                                  ]
+                              }
+                          ]
+                      }
+                  )
+              }
+          , meTs = read "2023-09-08 16:41:59.871489 UTC"
+          , meMessageDetails = MDMessage
+          }
+      )
+
+-- | These events happen when a user joins a channel
+-- and Slack displays a grey message like "John joined the channel".
+--
 -- https://github.com/serokell/tzbot/issues/107
 unit_Parse_message_channel_join_events :: Assertion
 unit_Parse_message_channel_join_events = do
@@ -54,3 +143,342 @@ unit_Parse_message_channel_join_events = do
         , meMessageDetails = MDUserJoinedChannel
         }
       )
+
+-- | These events happen when a user sends a message to a channel and then edits it.
+unit_Parse_message_edited :: Assertion
+unit_Parse_message_edited =
+  parseEither @_ @MessageEvent parseJSON [aesonQQ|
+  {
+      "channel": "C02N85E82LV",
+      "channel_type": "channel",
+      "event_ts": "1694188505.002400",
+      "hidden": true,
+      "message": {
+          "blocks": [
+              {
+                  "block_id": "NAiY",
+                  "elements": [
+                      {
+                          "elements": [
+                              {
+                                  "text": "BBB",
+                                  "type": "text"
+                              }
+                          ],
+                          "type": "rich_text_section"
+                      }
+                  ],
+                  "type": "rich_text"
+              }
+          ],
+          "client_msg_id": "f1d9ac1d-250f-494b-8906-83e61210d3db",
+          "edited": {
+              "ts": "1694188505.000000",
+              "user": "U02N85E78QM"
+          },
+          "source_team": "T02NDBHSWSG",
+          "team": "T02NDBHSWSG",
+          "text": "BBB",
+          "ts": "1694188495.898759",
+          "type": "message",
+          "user": "U02N85E78QM",
+          "user_team": "T02NDBHSWSG"
+      },
+      "previous_message": {
+          "blocks": [
+              {
+                  "block_id": "gVzT",
+                  "elements": [
+                      {
+                          "elements": [
+                              {
+                                  "text": "AAA",
+                                  "type": "text"
+                              }
+                          ],
+                          "type": "rich_text_section"
+                      }
+                  ],
+                  "type": "rich_text"
+              }
+          ],
+          "client_msg_id": "f1d9ac1d-250f-494b-8906-83e61210d3db",
+          "team": "T02NDBHSWSG",
+          "text": "AAA",
+          "ts": "1694188495.898759",
+          "type": "message",
+          "user": "U02N85E78QM"
+      },
+      "subtype": "message_changed",
+      "ts": "1694188505.002400",
+      "type": "message"
+  }
+  |] @?= Right
+    ( MessageEvent
+        { meChannel = ChannelId
+            { unChannelId = "C02N85E82LV" }
+        , meChannelType = Just CTChannel
+        , meMessage = Message
+            { mUser = UserId
+                { unUserId = "U02N85E78QM" }
+            , mText = "BBB"
+            , mMessageId = MessageId
+                { unMessageId = "1694188495.898759" }
+            , mTs = read "2023-09-08 15:54:55.898759 UTC"
+            , mThreadId = Nothing
+            , mEdited = True
+            , mSubType = Nothing
+            , msgBlocks = Just
+                ( WithUnknown
+                    { unUnknown = Right
+                        [ MessageBlock
+                            { mbElements =
+                                [ BEL1Plain
+                                    ( PlainBlockElementLevel1
+                                        { beType = WithUnknown { unUnknown = Right BETRichTextSection }
+                                        , beElements = Just
+                                            [ WithUnknown
+                                                { unUnknown = Right
+                                                    ( BEL2ElementText
+                                                        ( ElementText
+                                                            { etText = "BBB"
+                                                            , etStyle = Nothing
+                                                            }
+                                                        )
+                                                    )
+                                                }
+                                            ]
+                                        }
+                                    )
+                                ]
+                            }
+                        ]
+                    }
+                )
+            }
+        , meTs = read "2023-09-08 15:55:05.0024 UTC"
+        , meMessageDetails = MDMessageEdited
+            ( Message
+                { mUser = UserId
+                    { unUserId = "U02N85E78QM" }
+                , mText = "AAA"
+                , mMessageId = MessageId
+                    { unMessageId = "1694188495.898759" }
+                , mTs = read "2023-09-08 15:54:55.898759 UTC"
+                , mThreadId = Nothing
+                , mEdited = False
+                , mSubType = Nothing
+                , msgBlocks = Just
+                    ( WithUnknown
+                        { unUnknown = Right
+                            [ MessageBlock
+                                { mbElements =
+                                    [ BEL1Plain
+                                        ( PlainBlockElementLevel1
+                                            { beType = WithUnknown { unUnknown = Right BETRichTextSection }
+                                            , beElements = Just
+                                                [ WithUnknown
+                                                    { unUnknown = Right
+                                                        ( BEL2ElementText
+                                                            ( ElementText
+                                                                { etText = "AAA"
+                                                                , etStyle = Nothing
+                                                                }
+                                                            )
+                                                        )
+                                                    }
+                                                ]
+                                            }
+                                        )
+                                    ]
+                                }
+                            ]
+                        }
+                    )
+                }
+            )
+        }
+    )
+
+-- | These events happen when a user replies in a thread
+-- and checks the "Also send to #channel" checkbox.
+unit_Parse_message_with_broadcast :: Assertion
+unit_Parse_message_with_broadcast =
+  parseEither @_ @MessageEvent parseJSON [aesonQQ|
+  {
+      "channel": "C02N85E82LV",
+      "channel_type": "channel",
+      "event_ts": "1694190804.002600",
+      "hidden": true,
+      "message": {
+          "blocks": [
+              {
+                  "block_id": "kke",
+                  "elements": [
+                      {
+                          "elements": [
+                              {
+                                  "text": "This is a message with broadcast",
+                                  "type": "text"
+                              }
+                          ],
+                          "type": "rich_text_section"
+                      }
+                  ],
+                  "type": "rich_text"
+              }
+          ],
+          "client_msg_id": "203315b8-f848-475c-b0b5-da0db4acd993",
+          "root": {
+              "blocks": [
+                  {
+                      "block_id": "Sr5",
+                      "elements": [
+                          {
+                              "elements": [
+                                  {
+                                      "text": "First message",
+                                      "type": "text"
+                                  }
+                              ],
+                              "type": "rich_text_section"
+                          }
+                      ],
+                      "type": "rich_text"
+                  }
+              ],
+              "client_msg_id": "2e3a25aa-4b9e-4c78-bef0-be3b8656a53d",
+              "is_locked": false,
+              "latest_reply": "1694190803.567119",
+              "reply_count": 1,
+              "reply_users": [
+                  "U02N85E78QM"
+              ],
+              "reply_users_count": 1,
+              "team": "T02NDBHSWSG",
+              "text": "First message",
+              "thread_ts": "1694190770.058699",
+              "ts": "1694190770.058699",
+              "type": "message",
+              "user": "U02N85E78QM"
+          },
+          "subtype": "thread_broadcast",
+          "text": "This is a message with broadcast",
+          "thread_ts": "1694190770.058699",
+          "ts": "1694190803.567119",
+          "type": "message",
+          "user": "U02N85E78QM"
+      },
+      "previous_message": {
+          "blocks": [
+              {
+                  "block_id": "kke",
+                  "elements": [
+                      {
+                          "elements": [
+                              {
+                                  "text": "This is a message with broadcast",
+                                  "type": "text"
+                              }
+                          ],
+                          "type": "rich_text_section"
+                      }
+                  ],
+                  "type": "rich_text"
+              }
+          ],
+          "client_msg_id": "203315b8-f848-475c-b0b5-da0db4acd993",
+          "root": {
+              "blocks": [
+                  {
+                      "block_id": "Sr5",
+                      "elements": [
+                          {
+                              "elements": [
+                                  {
+                                      "text": "First message",
+                                      "type": "text"
+                                  }
+                              ],
+                              "type": "rich_text_section"
+                          }
+                      ],
+                      "type": "rich_text"
+                  }
+              ],
+              "client_msg_id": "2e3a25aa-4b9e-4c78-bef0-be3b8656a53d",
+              "is_locked": false,
+              "latest_reply": "1694190803.567119",
+              "reply_count": 1,
+              "reply_users": [
+                  "U02N85E78QM"
+              ],
+              "reply_users_count": 1,
+              "team": "T02NDBHSWSG",
+              "text": "First message",
+              "thread_ts": "1694190770.058699",
+              "ts": "1694190770.058699",
+              "type": "message",
+              "user": "U02N85E78QM"
+          },
+          "subtype": "thread_broadcast",
+          "text": "This is a message with broadcast",
+          "thread_ts": "1694190770.058699",
+          "ts": "1694190803.567119",
+          "type": "message",
+          "user": "U02N85E78QM"
+      },
+      "subtype": "message_changed",
+      "ts": "1694190804.002600",
+      "type": "message"
+  }
+  |] @?= Right
+    ( MessageEvent
+        { meChannel = ChannelId
+            { unChannelId = "C02N85E82LV" }
+        , meChannelType = Just CTChannel
+        , meMessage = Message
+            { mUser = UserId
+                { unUserId = "U02N85E78QM" }
+            , mText = "This is a message with broadcast"
+            , mMessageId = MessageId
+                { unMessageId = "1694190803.567119" }
+            , mTs = read "2023-09-08 16:33:23.567119 UTC"
+            , mThreadId = Just
+                ( ThreadId
+                    { unThreadId = "1694190770.058699" }
+                )
+            , mEdited = False
+            , mSubType = Just "thread_broadcast"
+            , msgBlocks = Just
+                ( WithUnknown
+                    { unUnknown = Right
+                        [ MessageBlock
+                            { mbElements =
+                                [ BEL1Plain
+                                    ( PlainBlockElementLevel1
+                                        { beType = WithUnknown { unUnknown = Right BETRichTextSection }
+                                        , beElements = Just
+                                            [ WithUnknown
+                                                { unUnknown = Right
+                                                    ( BEL2ElementText
+                                                        ( ElementText
+                                                            { etText = "This is a message with broadcast"
+                                                            , etStyle = Nothing
+                                                            }
+                                                        )
+                                                    )
+                                                }
+                                            ]
+                                        }
+                                    )
+                                ]
+                            }
+                        ]
+                    }
+                )
+            }
+        , meTs = read "2023-09-08 16:33:24.0026 UTC"
+        , meMessageDetails = MDMessageBroadcast
+        }
+    )


### PR DESCRIPTION
## Description

Whenever a user posts a message with a link, and Slack subsequently displays a preview of that URL, an event is sent to the server, and the server fails to parse it.

This PR fixes that and adds the `MDMessageUrlUnfurl` constructor.

## Related issue(s)

Fixed part of #108

<!--
Short description of how the PR relates to the issue, including an issue link.
For example:

- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).

If this PR does not fully resolve the linked issue and is not meant to close it,
replace `Fixed #` with `Fixed part of #`.
-->


## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock


#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).

## ✓ Release Checklist

- [x] I updated the version number in `package.yaml`.
- [x] (After merging) I created a new entry in the [releases](https://github.com/serokell/tzbot/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created using the format `vX.Y`
