### PR TITLE
[Chore] Update "actions/checkout"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
   validate:
     runs-on: [self-hosted, nix]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: check trailing whitespaces
         run: nix build -L .#checks.x86_64-linux.trailing-whitespace
@@ -43,7 +43,7 @@ jobs:
   build:
     runs-on: [self-hosted, nix]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: build
         run: nix build -L .#checks.x86_64-linux.build-all
@@ -52,7 +52,7 @@ jobs:
     runs-on: [self-hosted, nix]
     needs: [build]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: test
         run: nix build -L .#checks.x86_64-linux.test
@@ -66,7 +66,7 @@ jobs:
     needs: [test]
     if: ${{ github.ref == 'refs/heads/staging' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: deploy staging
         run: nix develop .#ci -c deploy .#staging --ssh-user deploy --skip-checks


### PR DESCRIPTION
Problem: node16 is now deprecated and github-runner provided by nixpkgs
no longer supports this runtime. However, "actions/checkout@v3" uses
this runtime.

Solution: Update CI pipeline to use "actions/checkout@v4".
